### PR TITLE
docs(.cursor): add timestamp sequencing to changelog rules

### DIFF
--- a/.cursor/rules/create-project-planton-changelog.mdc
+++ b/.cursor/rules/create-project-planton-changelog.mdc
@@ -86,21 +86,15 @@ Create a changelog when:
 
 ### File Naming
 ```
-YYYY-MM-DD-brief-descriptive-slug.md
-```
-
-For multiple changelogs on the same day, use numbered prefixes:
-```
-YYYY-MM-DD-01.brief-descriptive-slug.md
-YYYY-MM-DD-02.another-feature.md
+YYYY-MM-DD-HHMMSS-brief-descriptive-slug.md
 ```
 
 Examples:
-- `2025-10-18-pulumi-interactive-output-with-diff-support.md`
-- `2025-10-18-01.proto-field-defaults-support.md`
-- `2025-10-17-temporal-namespace-initialization-bug-fix.md`
+- `2025-10-18-153045-pulumi-interactive-output-with-diff-support.md`
+- `2025-10-18-091230-proto-field-defaults-support.md`
+- `2025-10-17-164500-temporal-namespace-initialization-bug-fix.md`
 
-Use current date and a clear, kebab-case slug describing the change.
+Use current date and time (24-hour format) followed by a clear, kebab-case slug describing the change. The timestamp (HHMMSS) ensures automatic chronological sorting when multiple changelogs are created on the same day.
 
 ### Required Metadata
 


### PR DESCRIPTION
## Summary

Updated both Planton Cloud and Project Planton changelog rules to include timestamps (HHMMSS) in filenames, ensuring proper chronological sequencing when multiple changelogs are created on the same day.

## Context

When creating multiple changelogs on the same day, the date-only filename format (`YYYY-MM-DD-slug.md`) made it difficult to determine the correct sequence. Files would sort alphabetically by slug rather than chronologically, making it hard to track the order of changes throughout the day.

## Changes

- Updated Planton Cloud changelog rule to use `YYYY-MM-DD-HHMMSS-slug.md` format
- Updated Project Planton changelog rule to use `YYYY-MM-DD-HHMMSS-slug.md` format
- Removed numbered prefix pattern from Project Planton rule (no longer needed)
- Updated filename examples in both rules to show timestamp format
- Added explanatory text about automatic chronological sorting

## Implementation notes

- Timestamps use 24-hour format (HHMMSS) for second-level granularity
- Natural alphabetical sorting now matches chronological order
- Existing changelogs without timestamps remain backward compatible
- No migration of existing changelog files required

## Breaking changes

None. The rules only affect new changelog creation. Existing changelogs continue to work as-is.

## Test plan

- Verified both rule files update correctly
- Confirmed no linter errors
- Validated filename format examples are clear and consistent

## Risks

Low risk. This only affects future changelog creation when rules are invoked. No existing functionality is impacted.

## Checklist

- [x] Docs updated (rules themselves are the documentation)
- [ ] Tests added/updated (N/A for documentation rules)
- [x] Backward compatible