### PR TITLE
feat(auth0): add E2E test automation for all 5 Auth0 components

### DIFF
--- a/.github/workflows/e2e-auth0.yaml
+++ b/.github/workflows/e2e-auth0.yaml
@@ -119,9 +119,12 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
 
           if [ -f results-auth0.xml ]; then
-            TESTS=$(grep -c '<testcase' results-auth0.xml 2>/dev/null || echo "0")
-            FAILURES=$(grep -oP 'failures="\K[0-9]+' results-auth0.xml 2>/dev/null | head -1 || echo "0")
-            SKIPPED=$(grep -c '<skipped' results-auth0.xml 2>/dev/null || echo "0")
+            TESTS="$(grep -c '<testcase' results-auth0.xml 2>/dev/null | tr -d '[:space:]')"
+            TESTS="${TESTS:-0}"
+            FAILURES="$(grep -oP 'failures="\K[0-9]+' results-auth0.xml 2>/dev/null | head -1 | tr -d '[:space:]')"
+            FAILURES="${FAILURES:-0}"
+            SKIPPED="$(grep -c '<skipped' results-auth0.xml 2>/dev/null | tr -d '[:space:]')"
+            SKIPPED="${SKIPPED:-0}"
             PASSED=$((TESTS - FAILURES - SKIPPED))
 
             echo "| Tests | Passed | Failed | Skipped |" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/e2e-auth0.yaml
+++ b/.github/workflows/e2e-auth0.yaml
@@ -1,0 +1,132 @@
+# =============================================================================
+# Auth0 E2E Tests
+# =============================================================================
+# Runs E2E tests for Auth0 components against a free-tier Auth0 tenant.
+# No Docker, kind, or kubectl needed -- Auth0 resources are SaaS API objects.
+#
+# Architecture:
+#   1. build-check: compile E2E code + go vet (fast gate, every trigger)
+#   2. e2e: run all Auth0 component tests (both Pulumi and Terraform)
+#
+# Triggers:
+#   - Pull requests (path-filtered): build-check only
+#   - Weekly schedule: full pipeline
+#   - Manual dispatch
+# =============================================================================
+
+name: e2e-auth0
+
+on:
+  schedule:
+    - cron: '0 4 * * 0' # Weekly Sunday 4am UTC (1 hour after Kubernetes)
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'apis/org/openmcf/provider/auth0/**'
+      - 'e2e/auth0/**'
+      - 'e2e/framework/**'
+      - 'pkg/iac/**'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/e2e-auth0.yaml'
+
+concurrency:
+  group: e2e-auth0-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  PULUMI_CONFIG_PASSPHRASE: ''
+
+jobs:
+  # ============================================================================
+  # Build Check -- fast compile + vet gate (every trigger)
+  # ============================================================================
+  build-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Compile Auth0 E2E tests
+        run: go test -tags=e2e -c -o /dev/null ./e2e/auth0/...
+
+      - name: Vet Auth0 E2E packages
+        run: go vet -tags=e2e ./e2e/auth0/...
+
+  # ============================================================================
+  # E2E -- run all Auth0 component tests
+  # ============================================================================
+  e2e:
+    needs: build-check
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
+      AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
+      AUTH0_CLIENT_SECRET: ${{ secrets.AUTH0_CLIENT_SECRET }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+
+      - name: Install Pulumi
+        run: curl -fsSL https://get.pulumi.com | sh && echo "$HOME/.pulumi/bin" >> "$GITHUB_PATH"
+
+      - name: Install OpenTofu
+        run: |
+          curl -fsSL https://get.opentofu.org/install-opentofu.sh -o install-opentofu.sh
+          chmod +x install-opentofu.sh
+          ./install-opentofu.sh --install-method standalone --skip-verify
+          rm install-opentofu.sh
+
+      - name: Run Auth0 E2E tests
+        run: |
+          gotestsum \
+            --format=testdox \
+            --junitfile=results-auth0.xml \
+            -- \
+            -tags=e2e \
+            -timeout=15m \
+            -v \
+            -count=1 \
+            ./e2e/auth0/...
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-results-auth0
+          path: results-auth0.xml
+          retention-days: 30
+
+      - name: Generate summary
+        if: always()
+        run: |
+          echo "## Auth0 E2E Results" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          if [ -f results-auth0.xml ]; then
+            TESTS=$(grep -c '<testcase' results-auth0.xml 2>/dev/null || echo "0")
+            FAILURES=$(grep -oP 'failures="\K[0-9]+' results-auth0.xml 2>/dev/null | head -1 || echo "0")
+            SKIPPED=$(grep -c '<skipped' results-auth0.xml 2>/dev/null || echo "0")
+            PASSED=$((TESTS - FAILURES - SKIPPED))
+
+            echo "| Tests | Passed | Failed | Skipped |" >> "$GITHUB_STEP_SUMMARY"
+            echo "|-------|--------|--------|---------|" >> "$GITHUB_STEP_SUMMARY"
+            echo "| $TESTS | $PASSED | $FAILURES | $SKIPPED |" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No test results found." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/e2e-kubernetes.yaml
+++ b/.github/workflows/e2e-kubernetes.yaml
@@ -203,10 +203,14 @@ jobs:
             [ -f "$f" ] || continue
             CELL=$(basename "$f" .xml | sed 's/^results-//')
 
-            TESTS=$(grep -c '<testcase' "$f" 2>/dev/null || echo "0")
-            FAILURES=$(grep -oP 'failures="\K[0-9]+' "$f" 2>/dev/null | head -1 || echo "0")
-            SKIPPED=$(grep -c '<skipped' "$f" 2>/dev/null || echo "0")
-            TIME=$(grep -oP 'time="\K[0-9.]+' "$f" 2>/dev/null | head -1 || echo "0")
+            TESTS="$(grep -c '<testcase' "$f" 2>/dev/null | tr -d '[:space:]')"
+            TESTS="${TESTS:-0}"
+            FAILURES="$(grep -oP 'failures="\K[0-9]+' "$f" 2>/dev/null | head -1 | tr -d '[:space:]')"
+            FAILURES="${FAILURES:-0}"
+            SKIPPED="$(grep -c '<skipped' "$f" 2>/dev/null | tr -d '[:space:]')"
+            SKIPPED="${SKIPPED:-0}"
+            TIME="$(grep -oP 'time="\K[0-9.]+' "$f" 2>/dev/null | head -1 | tr -d '[:space:]')"
+            TIME="${TIME:-0}"
             PASSED=$((TESTS - FAILURES - SKIPPED))
 
             TOTAL_TESTS=$((TOTAL_TESTS + TESTS))
@@ -228,7 +232,8 @@ jobs:
             echo "" >> "$GITHUB_STEP_SUMMARY"
             for f in results-*.xml; do
               [ -f "$f" ] || continue
-              FAILURES=$(grep -oP 'failures="\K[0-9]+' "$f" 2>/dev/null | head -1 || echo "0")
+              FAILURES="$(grep -oP 'failures="\K[0-9]+' "$f" 2>/dev/null | head -1 | tr -d '[:space:]')"
+              FAILURES="${FAILURES:-0}"
               [ "$FAILURES" -gt 0 ] || continue
 
               CELL=$(basename "$f" .xml | sed 's/^results-//')

--- a/Makefile
+++ b/Makefile
@@ -245,6 +245,20 @@ e2e-test-kubernetes-terraform-tier3:  ## Run Kubernetes Tier 3 Terraform (operat
 e2e-test-kubernetes-terraform-tier4:  ## Run Kubernetes Tier 4 Terraform (operators, addons) E2E tests
 	go test -tags=e2e -timeout=150m -v -count=1 -run "Test(KubernetesZalandoPostgresOperator|KubernetesStrimziKafkaOperator|KubernetesElasticOperator|KubernetesAltinityOperator|KubernetesGatewayApiCrds|KubernetesGhaRunnerScaleSetController|KubernetesRookCephOperator|KubernetesExternalSecrets|KubernetesTekton)_Terraform" ./e2e/...
 
+# ── Auth0 E2E targets ────────────────────────────────────────────────────────
+
+.PHONY: e2e-test-auth0
+e2e-test-auth0:  ## Run all Auth0 E2E tests (requires AUTH0_DOMAIN, AUTH0_CLIENT_ID, AUTH0_CLIENT_SECRET)
+	go test -tags=e2e -timeout=20m -v -count=1 ./e2e/auth0/...
+
+.PHONY: e2e-test-auth0-pulumi
+e2e-test-auth0-pulumi:  ## Run Auth0 Pulumi E2E tests only
+	go test -tags=e2e -timeout=20m -v -count=1 -run ".*_Pulumi" ./e2e/auth0/...
+
+.PHONY: e2e-test-auth0-terraform
+e2e-test-auth0-terraform:  ## Run Auth0 Terraform E2E tests only
+	go test -tags=e2e -timeout=20m -v -count=1 -run ".*_Terraform" ./e2e/auth0/...
+
 # ── Generic component E2E targets ────────────────────────────────────────────
 
 .PHONY: e2e-test-component

--- a/apis/org/openmcf/provider/auth0/aa_e2e/client.go
+++ b/apis/org/openmcf/provider/auth0/aa_e2e/client.go
@@ -1,0 +1,114 @@
+package aa_e2e
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// ManagementClient is a lightweight HTTP client for the Auth0 Management API.
+// It handles token acquisition via client_credentials and resource lookups
+// for E2E verification (exists / not-exists checks).
+type ManagementClient struct {
+	domain      string
+	accessToken string
+	httpClient  *http.Client
+}
+
+type tokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	ExpiresIn   int    `json:"expires_in"`
+}
+
+// NewManagementClient authenticates via client_credentials and returns a ready client.
+func NewManagementClient(domain, clientID, clientSecret string) (*ManagementClient, error) {
+	httpClient := &http.Client{Timeout: 30 * time.Second}
+
+	tokenURL := fmt.Sprintf("https://%s/oauth/token", domain)
+	payload, _ := json.Marshal(map[string]string{
+		"client_id":     clientID,
+		"client_secret": clientSecret,
+		"audience":      fmt.Sprintf("https://%s/api/v2/", domain),
+		"grant_type":    "client_credentials",
+	})
+
+	resp, err := httpClient.Post(tokenURL, "application/json", bytes.NewReader(payload))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to request access token")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, errors.Errorf("token request returned %d: %s", resp.StatusCode, body)
+	}
+
+	var tok tokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tok); err != nil {
+		return nil, errors.Wrap(err, "failed to decode token response")
+	}
+
+	return &ManagementClient{
+		domain:      domain,
+		accessToken: tok.AccessToken,
+		httpClient:  httpClient,
+	}, nil
+}
+
+// ResourceExists checks whether a resource at the given Management API path exists.
+// path is relative to /api/v2/ (e.g., "clients/abc123").
+// Returns true if 200, false if 404, error for anything else.
+func (c *ManagementClient) ResourceExists(path string) (bool, error) {
+	url := fmt.Sprintf("https://%s/api/v2/%s", c.domain, path)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to build request")
+	}
+	req.Header.Set("Authorization", "Bearer "+c.accessToken)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return false, errors.Wrapf(err, "GET %s failed", path)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return true, nil
+	case http.StatusNotFound:
+		return false, nil
+	default:
+		body, _ := io.ReadAll(resp.Body)
+		return false, errors.Errorf("GET %s returned %d: %s", path, resp.StatusCode, body)
+	}
+}
+
+// VerifyConnectivity does a lightweight check that the token and API are working.
+func (c *ManagementClient) VerifyConnectivity() error {
+	url := fmt.Sprintf("https://%s/api/v2/clients?per_page=1&fields=client_id", c.domain)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return errors.Wrap(err, "failed to build connectivity check request")
+	}
+	req.Header.Set("Authorization", "Bearer "+c.accessToken)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "connectivity check failed")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return errors.Errorf("connectivity check returned %d: %s", resp.StatusCode, body)
+	}
+	return nil
+}

--- a/apis/org/openmcf/provider/auth0/aa_e2e/harness.go
+++ b/apis/org/openmcf/provider/auth0/aa_e2e/harness.go
@@ -1,0 +1,133 @@
+// Package aa_e2e implements the E2E provider harness for Auth0,
+// using the Auth0 Management API for resource verification.
+package aa_e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/pkg/errors"
+	"github.com/plantonhq/openmcf/apis/org/openmcf/provider/auth0/aa_e2e/verify"
+	"github.com/plantonhq/openmcf/e2e/framework/provider"
+)
+
+// Harness manages Auth0 E2E test lifecycle.
+// Unlike Kubernetes (kind cluster), Auth0 is a SaaS API -- Setup validates
+// credentials and Teardown is a no-op.
+type Harness struct {
+	client *ManagementClient
+
+	// mu guards deployedIDs which is written by VerifyDeployed
+	// and read by VerifyDestroyed.
+	mu          sync.Mutex
+	deployedIDs map[string]string // component -> resource ID
+}
+
+// NewHarness creates an Auth0 test harness.
+// Credentials are read from AUTH0_DOMAIN, AUTH0_CLIENT_ID, AUTH0_CLIENT_SECRET env vars.
+func NewHarness() *Harness {
+	return &Harness{
+		deployedIDs: make(map[string]string),
+	}
+}
+
+// Setup authenticates with the Auth0 Management API and verifies connectivity.
+func (h *Harness) Setup(ctx context.Context) error {
+	domain := os.Getenv("AUTH0_DOMAIN")
+	clientID := os.Getenv("AUTH0_CLIENT_ID")
+	clientSecret := os.Getenv("AUTH0_CLIENT_SECRET")
+
+	if domain == "" || clientID == "" || clientSecret == "" {
+		return errors.New("AUTH0_DOMAIN, AUTH0_CLIENT_ID, and AUTH0_CLIENT_SECRET must be set")
+	}
+
+	fmt.Printf("  [auth0] Authenticating with tenant %s...\n", domain)
+
+	client, err := NewManagementClient(domain, clientID, clientSecret)
+	if err != nil {
+		return errors.Wrap(err, "failed to create Auth0 Management API client")
+	}
+
+	if err := client.VerifyConnectivity(); err != nil {
+		return errors.Wrap(err, "Auth0 Management API connectivity check failed")
+	}
+
+	h.client = client
+	fmt.Printf("  [auth0] Authenticated and connected to %s\n", domain)
+	return nil
+}
+
+// Teardown is a no-op for Auth0 (no infrastructure to destroy).
+func (h *Harness) Teardown(ctx context.Context) error {
+	return nil
+}
+
+// VerifyDeployed checks that the deployed Auth0 resource exists via the Management API.
+// The resource ID is extracted from stack outputs and stored for VerifyDestroyed.
+func (h *Harness) VerifyDeployed(ctx context.Context, component string, outputs map[string]interface{}) error {
+	v, err := verify.GetVerifier(component)
+	if err != nil {
+		return err
+	}
+
+	id := extractResourceID(outputs)
+	if id == "" {
+		return errors.Errorf("no resource ID found in outputs for %s", component)
+	}
+
+	// Store for VerifyDestroyed
+	h.mu.Lock()
+	key := componentKey(ctx, component)
+	h.deployedIDs[key] = id
+	h.mu.Unlock()
+
+	return v.VerifyExists(h.client, id)
+}
+
+// VerifyDestroyed confirms that the previously deployed Auth0 resource no longer exists.
+func (h *Harness) VerifyDestroyed(ctx context.Context, component string) error {
+	v, err := verify.GetVerifier(component)
+	if err != nil {
+		return err
+	}
+
+	h.mu.Lock()
+	key := componentKey(ctx, component)
+	id := h.deployedIDs[key]
+	h.mu.Unlock()
+
+	if id == "" {
+		return errors.Errorf("no stored resource ID for %s -- VerifyDeployed may not have run", component)
+	}
+
+	return v.VerifyAbsent(h.client, id)
+}
+
+// extractResourceID pulls the Auth0 resource ID from stack outputs.
+// Pulumi exports "id" for all Auth0 components; Terraform outputs vary
+// but all include an "id" key.
+func extractResourceID(outputs map[string]interface{}) string {
+	if outputs == nil {
+		return ""
+	}
+	if id, ok := outputs["id"]; ok {
+		switch v := id.(type) {
+		case string:
+			return v
+		default:
+			return fmt.Sprintf("%v", v)
+		}
+	}
+	return ""
+}
+
+// componentKey creates a unique lookup key combining the manifest path (from context)
+// and component name, so concurrent tests for the same component type don't collide.
+func componentKey(ctx context.Context, component string) string {
+	if mp, ok := ctx.Value(provider.ManifestPathKey{}).(string); ok && mp != "" {
+		return mp + "::" + component
+	}
+	return component
+}

--- a/apis/org/openmcf/provider/auth0/aa_e2e/verify/verifier.go
+++ b/apis/org/openmcf/provider/auth0/aa_e2e/verify/verifier.go
@@ -1,0 +1,70 @@
+package verify
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+// ResourceChecker can test whether a Management API resource exists.
+type ResourceChecker interface {
+	ResourceExists(path string) (bool, error)
+}
+
+// Verifier checks Auth0 resources for a single component type.
+type Verifier interface {
+	VerifyExists(checker ResourceChecker, id string) error
+	VerifyAbsent(checker ResourceChecker, id string) error
+}
+
+// apiPathVerifier is the common implementation: one Management API path template.
+type apiPathVerifier struct {
+	component  string
+	pathFormat string // e.g. "clients/%s"
+}
+
+func (v *apiPathVerifier) VerifyExists(checker ResourceChecker, id string) error {
+	path := v.formatPath(id)
+	exists, err := checker.ResourceExists(path)
+	if err != nil {
+		return errors.Wrapf(err, "%s verify-exists failed", v.component)
+	}
+	if !exists {
+		return errors.Errorf("%s %s not found after deploy", v.component, id)
+	}
+	return nil
+}
+
+func (v *apiPathVerifier) VerifyAbsent(checker ResourceChecker, id string) error {
+	path := v.formatPath(id)
+	exists, err := checker.ResourceExists(path)
+	if err != nil {
+		return errors.Wrapf(err, "%s verify-absent failed", v.component)
+	}
+	if exists {
+		return errors.Errorf("%s %s still exists after destroy", v.component, id)
+	}
+	return nil
+}
+
+func (v *apiPathVerifier) formatPath(id string) string {
+	return fmt.Sprintf(v.pathFormat, id)
+}
+
+// verifiers maps component name to the Management API path used for verification.
+var verifiers = map[string]Verifier{
+	"auth0client":         &apiPathVerifier{component: "auth0client", pathFormat: "clients/%s"},
+	"auth0connection":     &apiPathVerifier{component: "auth0connection", pathFormat: "connections/%s"},
+	"auth0resourceserver": &apiPathVerifier{component: "auth0resourceserver", pathFormat: "resource-servers/%s"},
+	"auth0action":         &apiPathVerifier{component: "auth0action", pathFormat: "actions/actions/%s"},
+	"auth0eventstream":    &apiPathVerifier{component: "auth0eventstream", pathFormat: "event-streams/%s"},
+}
+
+// GetVerifier returns the verifier for a component, or an error if unknown.
+func GetVerifier(component string) (Verifier, error) {
+	v, ok := verifiers[component]
+	if !ok {
+		return nil, errors.Errorf("no Auth0 verifier registered for component %q", component)
+	}
+	return v, nil
+}

--- a/apis/org/openmcf/provider/auth0/auth0action/v1/docs/compliance.md
+++ b/apis/org/openmcf/provider/auth0/auth0action/v1/docs/compliance.md
@@ -1,0 +1,40 @@
+# Auth0 Action - Compliance
+
+## Regulatory Frameworks
+
+Auth0 supports the following compliance frameworks:
+
+| Framework | Status | Notes |
+|-----------|--------|-------|
+| SOC 2 Type II | Certified | Annual audit cycle |
+| ISO 27001:2022 | Certified | Information security management |
+| ISO 27018:2019 | Certified | PII protection in public clouds |
+| HIPAA | BAA Available | Enterprise plans only |
+| PCI DSS Level 1 | Certified | Service provider certification |
+| FedRAMP Moderate | Authorized | US government workloads |
+| CSA STAR Level 2 | Certified | Cloud security assurance |
+| GDPR | Compliant | Data Processing Agreement available |
+| CCPA | Compliant | California consumer privacy |
+| Privacy Shield | Historical | Deprecated framework, replaced by SCCs |
+
+## Action-Specific Compliance Notes
+
+### Code as Configuration
+
+Actions contain executable code that runs in Auth0's infrastructure. For regulated environments, treat Action code as auditable configuration. Maintain version control for all Action source code outside Auth0 (e.g., in the openmcf repository) to satisfy change management requirements.
+
+### Data Access in Actions
+
+Post-login Actions receive the authenticated user's profile data. If your Action logic processes PII (name, email, phone), ensure the Action's behavior complies with applicable data protection regulations. Avoid logging PII in Action console output.
+
+### Custom Claims and Data Minimization
+
+Actions that add custom claims to tokens should follow GDPR data minimization principles. Only include claims that the downstream API requires. Token claims are visible to any party that can decode the token (access tokens are JWTs).
+
+### Audit Trail
+
+All Action CRUD operations (create, update, deploy, delete) are recorded in Auth0 tenant logs. Action execution failures are also logged. Log retention depends on plan tier (2 days free, 30 days enterprise).
+
+### Third-Party Dependencies
+
+Actions that use npm packages introduce third-party code into the authentication pipeline. For compliance-sensitive environments, maintain an approved package list and review transitive dependencies.

--- a/apis/org/openmcf/provider/auth0/auth0action/v1/docs/cost.md
+++ b/apis/org/openmcf/provider/auth0/auth0action/v1/docs/cost.md
@@ -1,0 +1,39 @@
+# Auth0 Action - Cost
+
+## Pricing Model
+
+Auth0 pricing is based on Monthly Active Users (MAUs), not on the number of resources created. Actions are free API objects with no per-resource cost.
+
+## Free Tier
+
+The Auth0 Free plan includes:
+
+- 25,000 MAUs
+- 1 tenant
+- Unlimited Actions
+- Unlimited Action triggers (post-login, pre-registration, etc.)
+
+## Cost Impact
+
+Creating, updating, or deleting Auth0 Action resources has no direct billing impact. There is no charge per Action definition, per deployment, or per trigger binding.
+
+The only cost driver is the number of monthly active users authenticating through your tenant. Actions execute as part of the authentication pipeline at no additional cost.
+
+## Execution Considerations
+
+While Actions are free to define, they affect authentication latency. Each Action in a trigger's pipeline adds execution time to the authentication flow:
+
+| Factor | Impact |
+|--------|--------|
+| Action code complexity | Directly increases login latency |
+| External API calls in Actions | Adds network round-trip time |
+| Number of Actions per trigger | Cumulative latency increase |
+| Action timeout | 20 seconds maximum per Action |
+
+## Rate Limits
+
+The Auth0 Management API enforces rate limits on Action operations. Deploying Actions (creating new versions) counts against the Management API rate limit. Action executions during authentication flows are governed by separate per-tenant limits.
+
+## npm Dependencies
+
+Actions can include npm packages. There is no cost for npm dependencies, but each Action deployment must resolve and bundle its dependencies, which affects deployment time.

--- a/apis/org/openmcf/provider/auth0/auth0action/v1/docs/permissions.md
+++ b/apis/org/openmcf/provider/auth0/auth0action/v1/docs/permissions.md
@@ -1,0 +1,35 @@
+# Auth0 Action - Permissions
+
+## Management API Scopes
+
+Auth0 Action resources require the following Management API scopes for CRUD operations. These scopes must be granted to the M2M application used for infrastructure automation.
+
+| Operation | Scope | Description |
+|-----------|-------|-------------|
+| Read | `read:actions` | List and retrieve Action definitions and their code |
+| Create | `create:actions` | Create new Actions with code, triggers, and secrets |
+| Update | `update:actions` | Modify Action code, dependencies, and secrets |
+| Delete | `delete:actions` | Remove Actions from the tenant |
+
+## Deployment and Trigger Scopes
+
+Managing Action deployments and trigger bindings requires the same core scopes. The following operations are covered by the scopes above:
+
+| Operation | Required Scope | Description |
+|-----------|---------------|-------------|
+| Deploy Action | `update:actions` | Deploy a draft Action version to the pipeline |
+| List versions | `read:actions` | Retrieve Action version history |
+| Get trigger bindings | `read:actions` | List Actions bound to a specific trigger |
+| Update trigger bindings | `update:actions` | Reorder or change Actions bound to a trigger |
+
+## Minimum Required Scopes
+
+For basic lifecycle management (create, read, update, deploy, delete), the minimum required scopes are:
+
+```
+read:actions create:actions update:actions delete:actions
+```
+
+## Secrets in Actions
+
+Action secrets (environment variables) are managed through the Action update endpoint. No additional scopes are required beyond `update:actions` to set or modify Action secrets.

--- a/apis/org/openmcf/provider/auth0/auth0action/v1/docs/security.md
+++ b/apis/org/openmcf/provider/auth0/auth0action/v1/docs/security.md
@@ -1,0 +1,54 @@
+# Auth0 Action - Security
+
+## Platform Security Posture
+
+Auth0 maintains the following certifications and security standards:
+
+- SOC 2 Type II (annual audit)
+- ISO 27001, ISO 27018 (privacy controls)
+- HIPAA BAA available on enterprise plans
+- PCI DSS Level 1 Service Provider
+- FedRAMP Authorized (moderate baseline)
+- CSA STAR Level 2
+- GDPR compliant with Data Processing Agreement
+
+## Data Protection
+
+- **Data residency**: US, EU, AU regions
+- **Encryption in transit**: TLS 1.2+
+- **Encryption at rest**: AES-256
+- **Penetration testing**: Annual third-party assessments
+
+## Action-Specific Security Notes
+
+### Sandboxed Runtime
+
+Action code runs in Auth0's sandboxed Node.js runtime environment. Each Action execution is isolated -- Actions cannot access the filesystem, spawn processes, or communicate with other Actions except through the event/API objects provided by Auth0.
+
+### Secrets Management
+
+Actions support injecting secrets via environment variables configured in the Auth0 dashboard or Management API. These secrets are:
+
+- Encrypted at rest in Auth0's configuration store
+- Available to Action code via `event.secrets`
+- Not logged or exposed in Action execution logs
+- Scoped to a single Action (not shared across Actions)
+
+Never hardcode credentials in Action source code. Always use the secrets mechanism.
+
+### Code Execution Context
+
+Actions in the post-login trigger receive the full user profile and authentication context. The Action code has access to:
+
+- User profile data (email, name, metadata)
+- Authentication method details (connection, MFA status)
+- Client information (application making the request)
+- The ability to modify tokens, deny access, or redirect users
+
+### Supply Chain Security
+
+Actions can include npm dependencies. Auth0 resolves and bundles these at deploy time. Pin dependency versions to avoid unintended updates. Review dependencies for known vulnerabilities before deploying to production.
+
+### Action Versioning
+
+Auth0 maintains a version history for each Action. Only the deployed version executes in the authentication pipeline. Draft versions can be tested before deployment.

--- a/apis/org/openmcf/provider/auth0/auth0action/v1/e2e/profile.yaml
+++ b/apis/org/openmcf/provider/auth0/auth0action/v1/e2e/profile.yaml
@@ -1,0 +1,11 @@
+apiVersion: qa.openmcf.org/v1
+kind: ComponentE2EProfile
+metadata:
+  name: auth0action
+spec:
+  tier: 1
+  status: green
+  validated_provisioners:
+    - pulumi
+    - terraform
+  timeout_minutes: 5

--- a/apis/org/openmcf/provider/auth0/auth0action/v1/e2e/scenarios/minimal.yaml
+++ b/apis/org/openmcf/provider/auth0/auth0action/v1/e2e/scenarios/minimal.yaml
@@ -1,0 +1,16 @@
+apiVersion: auth0.openmcf.org/v1
+kind: Auth0Action
+metadata:
+  name: e2e-post-login
+  org: e2e-org
+  env: testing
+spec:
+  supported_trigger:
+    id: post-login
+    version: v3
+  code: |
+    exports.onExecutePostLogin = async (event, api) => {
+      api.idToken.setCustomClaim('https://e2e.openmcf.org/tested', true);
+    };
+  runtime: node22
+  deploy: true

--- a/apis/org/openmcf/provider/auth0/auth0action/v1/iac/tf/provider.tf
+++ b/apis/org/openmcf/provider/auth0/auth0action/v1/iac/tf/provider.tf
@@ -1,16 +1,3 @@
-# Auth0 Provider Configuration
-# Documentation: https://registry.terraform.io/providers/auth0/auth0/latest/docs
-
-variable "auth0_credential" {
-  description = "Auth0 API authentication credentials"
-  type = object({
-    domain        = string
-    client_id     = string
-    client_secret = string
-  })
-  sensitive = true
-}
-
 terraform {
   required_version = ">= 1.0"
 
@@ -20,10 +7,4 @@ terraform {
       version = "~> 1.0"
     }
   }
-}
-
-provider "auth0" {
-  domain        = var.auth0_credential.domain
-  client_id     = var.auth0_credential.client_id
-  client_secret = var.auth0_credential.client_secret
 }

--- a/apis/org/openmcf/provider/auth0/auth0client/v1/docs/compliance.md
+++ b/apis/org/openmcf/provider/auth0/auth0client/v1/docs/compliance.md
@@ -1,0 +1,36 @@
+# Auth0 Client - Compliance
+
+## Regulatory Frameworks
+
+Auth0 supports the following compliance frameworks:
+
+| Framework | Status | Notes |
+|-----------|--------|-------|
+| SOC 2 Type II | Certified | Annual audit cycle |
+| ISO 27001:2022 | Certified | Information security management |
+| ISO 27018:2019 | Certified | PII protection in public clouds |
+| HIPAA | BAA Available | Enterprise plans only |
+| PCI DSS Level 1 | Certified | Service provider certification |
+| FedRAMP Moderate | Authorized | US government workloads |
+| CSA STAR Level 2 | Certified | Cloud security assurance |
+| GDPR | Compliant | Data Processing Agreement available |
+| CCPA | Compliant | California consumer privacy |
+| Privacy Shield | Historical | Deprecated framework, replaced by SCCs |
+
+## Client-Specific Compliance Notes
+
+### Data Residency
+
+Auth0 tenants are region-locked at creation. Client resources inherit the tenant's data residency region (US, EU, or AU). Authentication data processed by clients stays within the designated region.
+
+### Audit Logging
+
+All client CRUD operations are recorded in Auth0 tenant logs. These logs capture the Management API actor, timestamp, and operation details. Log retention depends on the plan tier (2 days free, 30 days enterprise).
+
+### Token Data
+
+Tokens issued by Auth0 clients may contain user PII (name, email) in ID token claims. Ensure downstream systems handling these tokens comply with applicable data protection regulations.
+
+### Consent Management
+
+For GDPR-regulated applications, Auth0 clients can be configured to display consent prompts during authentication. This is managed through the client's login flow configuration.

--- a/apis/org/openmcf/provider/auth0/auth0client/v1/docs/cost.md
+++ b/apis/org/openmcf/provider/auth0/auth0client/v1/docs/cost.md
@@ -1,0 +1,33 @@
+# Auth0 Client - Cost
+
+## Pricing Model
+
+Auth0 pricing is based on Monthly Active Users (MAUs), not on the number of resources created. Auth0 Applications (clients) are free API objects with no per-resource cost.
+
+## Free Tier
+
+The Auth0 Free plan includes:
+
+- 25,000 MAUs
+- 1 tenant
+- Unlimited social connections
+- Unlimited applications (clients)
+
+## Cost Impact
+
+Creating, updating, or deleting Auth0 client resources has no direct billing impact. There is no charge per application regardless of type (SPA, Web, M2M, Native).
+
+The only cost driver is the number of monthly active users authenticating through your tenant. If your MAU count stays within the free tier, all client resources remain free.
+
+## M2M Token Considerations
+
+Machine-to-machine (M2M) applications consume M2M token grants. The free plan includes 1,000 M2M tokens per month. Exceeding this limit requires a paid plan. Each M2M client credentials grant counts against this quota regardless of which M2M application issues the request.
+
+## Paid Plan Thresholds
+
+| Plan | MAU Limit | M2M Tokens/Month |
+|------|-----------|-------------------|
+| Free | 25,000 | 1,000 |
+| Essentials | Custom | 5,000 |
+| Professional | Custom | 10,000 |
+| Enterprise | Custom | Negotiated |

--- a/apis/org/openmcf/provider/auth0/auth0client/v1/docs/permissions.md
+++ b/apis/org/openmcf/provider/auth0/auth0client/v1/docs/permissions.md
@@ -1,0 +1,39 @@
+# Auth0 Client - Permissions
+
+## Management API Scopes
+
+Auth0 client resources require the following Management API scopes for CRUD operations. These scopes must be granted to the M2M application used for infrastructure automation.
+
+| Operation | Scope | Description |
+|-----------|-------|-------------|
+| Read | `read:clients` | List and retrieve application configurations |
+| Create | `create:clients` | Create new applications (SPA, Web, M2M, Native) |
+| Update | `update:clients` | Modify application settings, callbacks, and grants |
+| Delete | `delete:clients` | Remove applications from the tenant |
+
+## Additional Scopes
+
+Depending on the client configuration, these supplementary scopes may also be required:
+
+| Operation | Scope | Description |
+|-----------|-------|-------------|
+| Read grants | `read:client_grants` | List client grant associations |
+| Create grants | `create:client_grants` | Associate clients with APIs |
+| Update grants | `update:client_grants` | Modify granted scopes for a client-API pair |
+| Delete grants | `delete:client_grants` | Remove client grant associations |
+| Read keys | `read:client_keys` | Retrieve client signing credentials |
+| Update keys | `update:client_keys` | Rotate client signing credentials |
+
+## Minimum Required Scopes
+
+For basic lifecycle management (create, read, update, delete), the minimum required scopes are:
+
+```
+read:clients create:clients update:clients delete:clients
+```
+
+If the automation also manages which APIs a client can access, add:
+
+```
+read:client_grants create:client_grants update:client_grants delete:client_grants
+```

--- a/apis/org/openmcf/provider/auth0/auth0client/v1/docs/security.md
+++ b/apis/org/openmcf/provider/auth0/auth0client/v1/docs/security.md
@@ -1,0 +1,41 @@
+# Auth0 Client - Security
+
+## Platform Security Posture
+
+Auth0 maintains the following certifications and security standards:
+
+- SOC 2 Type II (annual audit)
+- ISO 27001, ISO 27018 (privacy controls)
+- HIPAA BAA available on enterprise plans
+- PCI DSS Level 1 Service Provider
+- FedRAMP Authorized (moderate baseline)
+- CSA STAR Level 2
+- GDPR compliant with Data Processing Agreement
+
+## Data Protection
+
+- **Data residency**: US, EU, AU regions
+- **Encryption in transit**: TLS 1.2+
+- **Encryption at rest**: AES-256
+- **Penetration testing**: Annual third-party assessments
+
+## Client-Specific Security Notes
+
+### Client Secrets
+
+Client secrets are sensitive credentials that must be protected. How secrets apply depends on the application type:
+
+- **SPA applications**: Use PKCE (Proof Key for Code Exchange) and do not have a client secret. This is the recommended approach for public clients.
+- **Web applications**: Have a client secret that must be stored server-side. Never expose this in client-side code.
+- **M2M applications**: Authenticate entirely via client_id and client_secret. These credentials grant full API access as configured.
+- **Native applications**: Treated as public clients. Use PKCE instead of client secrets.
+
+### Token Security
+
+- Access tokens should use short expiration times (default: 86400 seconds).
+- Refresh tokens should be configured with rotation and absolute lifetime limits.
+- ID tokens contain user claims and should not be sent to APIs as access credentials.
+
+### Callback URL Validation
+
+Auth0 validates redirect URIs strictly. Only registered callback URLs are accepted during authentication flows. Wildcard subdomains are supported but should be used cautiously.

--- a/apis/org/openmcf/provider/auth0/auth0client/v1/e2e/profile.yaml
+++ b/apis/org/openmcf/provider/auth0/auth0client/v1/e2e/profile.yaml
@@ -1,0 +1,11 @@
+apiVersion: qa.openmcf.org/v1
+kind: ComponentE2EProfile
+metadata:
+  name: auth0client
+spec:
+  tier: 1
+  status: green
+  validated_provisioners:
+    - pulumi
+    - terraform
+  timeout_minutes: 5

--- a/apis/org/openmcf/provider/auth0/auth0client/v1/e2e/scenarios/minimal.yaml
+++ b/apis/org/openmcf/provider/auth0/auth0client/v1/e2e/scenarios/minimal.yaml
@@ -1,0 +1,20 @@
+apiVersion: auth0.openmcf.org/v1
+kind: Auth0Client
+metadata:
+  name: e2e-spa-minimal
+  org: e2e-org
+  env: testing
+spec:
+  application_type: spa
+  description: E2E minimal SPA application
+  callbacks:
+    - http://localhost:3000/callback
+  allowed_logout_urls:
+    - http://localhost:3000
+  web_origins:
+    - http://localhost:3000
+  grant_types:
+    - authorization_code
+    - refresh_token
+  oidc_conformant: true
+  is_first_party: true

--- a/apis/org/openmcf/provider/auth0/auth0client/v1/iac/tf/outputs.tf
+++ b/apis/org/openmcf/provider/auth0/auth0client/v1/iac/tf/outputs.tf
@@ -24,6 +24,7 @@ output "application_type" {
 output "signing_keys" {
   description = "Signing keys for this client (for RS256 token verification)"
   value       = auth0_client.this.signing_keys
+  sensitive   = true
 }
 
 

--- a/apis/org/openmcf/provider/auth0/auth0client/v1/iac/tf/provider.tf
+++ b/apis/org/openmcf/provider/auth0/auth0client/v1/iac/tf/provider.tf
@@ -1,26 +1,3 @@
-# Auth0 Provider Configuration
-# This file configures the Auth0 Terraform provider
-# Documentation: https://registry.terraform.io/providers/auth0/auth0/latest/docs
-
-# Variables for Auth0 authentication
-variable "auth0_credential" {
-  description = "Auth0 API authentication credentials"
-  type = object({
-    # Auth0 tenant domain (e.g., your-tenant.auth0.com or custom domain)
-    domain = string
-
-    # Auth0 Machine-to-Machine application Client ID
-    # Create in Auth0 Dashboard: Applications -> Create Application -> Machine to Machine
-    client_id = string
-
-    # Auth0 Machine-to-Machine application Client Secret
-    # Shown in the application settings after creation
-    client_secret = string
-  })
-  sensitive = true
-}
-
-# Configure the Auth0 Provider
 terraform {
   required_version = ">= 1.0"
 
@@ -31,13 +8,3 @@ terraform {
     }
   }
 }
-
-# Provider configuration
-# The provider uses domain, client_id, and client_secret for API authentication
-provider "auth0" {
-  domain        = var.auth0_credential.domain
-  client_id     = var.auth0_credential.client_id
-  client_secret = var.auth0_credential.client_secret
-}
-
-

--- a/apis/org/openmcf/provider/auth0/auth0connection/v1/docs/compliance.md
+++ b/apis/org/openmcf/provider/auth0/auth0connection/v1/docs/compliance.md
@@ -1,0 +1,40 @@
+# Auth0 Connection - Compliance
+
+## Regulatory Frameworks
+
+Auth0 supports the following compliance frameworks:
+
+| Framework | Status | Notes |
+|-----------|--------|-------|
+| SOC 2 Type II | Certified | Annual audit cycle |
+| ISO 27001:2022 | Certified | Information security management |
+| ISO 27018:2019 | Certified | PII protection in public clouds |
+| HIPAA | BAA Available | Enterprise plans only |
+| PCI DSS Level 1 | Certified | Service provider certification |
+| FedRAMP Moderate | Authorized | US government workloads |
+| CSA STAR Level 2 | Certified | Cloud security assurance |
+| GDPR | Compliant | Data Processing Agreement available |
+| CCPA | Compliant | California consumer privacy |
+| Privacy Shield | Historical | Deprecated framework, replaced by SCCs |
+
+## Connection-Specific Compliance Notes
+
+### Password Storage
+
+Database connections store credentials using bcrypt hashing. Auth0's password storage practices comply with NIST SP 800-63B guidelines for memorized secret verifiers. Password history and complexity policies are configurable per connection.
+
+### Social Identity Data
+
+Social connections import user profile data from external identity providers. This data is subject to the privacy policies of both Auth0 and the upstream provider. Ensure your application's privacy policy covers data received from social logins.
+
+### Enterprise Federation
+
+SAML and OIDC connections federate authentication to external identity providers. Auth0 acts as a relying party. Compliance responsibility for the upstream identity provider's security posture remains with the organization operating that provider.
+
+### Audit Trail
+
+All connection CRUD operations and authentication events are captured in Auth0 tenant logs. Login events include connection name, client, and result. Log retention depends on plan tier.
+
+### Data Residency
+
+Connection configurations are stored in the tenant's designated region (US, EU, or AU). User profile data from database connections is stored in the same region.

--- a/apis/org/openmcf/provider/auth0/auth0connection/v1/docs/cost.md
+++ b/apis/org/openmcf/provider/auth0/auth0connection/v1/docs/cost.md
@@ -1,0 +1,37 @@
+# Auth0 Connection - Cost
+
+## Pricing Model
+
+Auth0 pricing is based on Monthly Active Users (MAUs), not on the number of resources created. Authentication connections are free API objects with no per-resource cost.
+
+## Free Tier
+
+The Auth0 Free plan includes:
+
+- 25,000 MAUs
+- 1 tenant
+- Unlimited social connections
+- Unlimited database connections
+
+## Cost Impact
+
+Creating, updating, or deleting Auth0 connection resources has no direct billing impact. There is no charge per connection regardless of type (Database, Social, Enterprise, SAML, OIDC, Azure AD).
+
+The only cost driver is the number of monthly active users authenticating through your tenant.
+
+## Enterprise Connection Considerations
+
+While connections themselves are free objects, certain enterprise connection types (SAML, OIDC, Azure AD) are only available on paid plans:
+
+| Connection Type | Minimum Plan |
+|----------------|--------------|
+| Database | Free |
+| Social (Google, GitHub, etc.) | Free |
+| SAML | Essentials |
+| OIDC | Essentials |
+| Azure AD | Essentials |
+| LDAP/AD | Enterprise |
+
+## Social Connection Limits
+
+The free plan allows unlimited social connections, but each social provider requires its own OAuth app registration (e.g., Google Cloud Console, GitHub OAuth App). Auth0 provides default development keys for testing, but production deployments should use custom keys.

--- a/apis/org/openmcf/provider/auth0/auth0connection/v1/docs/permissions.md
+++ b/apis/org/openmcf/provider/auth0/auth0connection/v1/docs/permissions.md
@@ -1,0 +1,34 @@
+# Auth0 Connection - Permissions
+
+## Management API Scopes
+
+Auth0 connection resources require the following Management API scopes for CRUD operations. These scopes must be granted to the M2M application used for infrastructure automation.
+
+| Operation | Scope | Description |
+|-----------|-------|-------------|
+| Read | `read:connections` | List and retrieve connection configurations |
+| Create | `create:connections` | Create new connections (Database, Social, Enterprise) |
+| Update | `update:connections` | Modify connection settings, enabled clients, and options |
+| Delete | `delete:connections` | Remove connections from the tenant |
+
+## Additional Scopes
+
+Depending on the connection type and operations performed, these supplementary scopes may be required:
+
+| Operation | Scope | Description |
+|-----------|-------|-------------|
+| Read users | `read:users` | List users associated with a connection |
+| Delete users | `delete:users` | Remove users from a database connection |
+| Read stats | `read:stats` | Retrieve connection usage statistics |
+
+## Minimum Required Scopes
+
+For basic lifecycle management (create, read, update, delete), the minimum required scopes are:
+
+```
+read:connections create:connections update:connections delete:connections
+```
+
+## Connection-Client Association
+
+Connections are enabled for specific clients via the `enabled_clients` property on the connection object. Modifying this association requires `update:connections` scope. No additional client-specific scopes are needed for this operation.

--- a/apis/org/openmcf/provider/auth0/auth0connection/v1/docs/security.md
+++ b/apis/org/openmcf/provider/auth0/auth0connection/v1/docs/security.md
@@ -1,0 +1,40 @@
+# Auth0 Connection - Security
+
+## Platform Security Posture
+
+Auth0 maintains the following certifications and security standards:
+
+- SOC 2 Type II (annual audit)
+- ISO 27001, ISO 27018 (privacy controls)
+- HIPAA BAA available on enterprise plans
+- PCI DSS Level 1 Service Provider
+- FedRAMP Authorized (moderate baseline)
+- CSA STAR Level 2
+- GDPR compliant with Data Processing Agreement
+
+## Data Protection
+
+- **Data residency**: US, EU, AU regions
+- **Encryption in transit**: TLS 1.2+
+- **Encryption at rest**: AES-256
+- **Penetration testing**: Annual third-party assessments
+
+## Connection-Specific Security Notes
+
+### Social Connection Secrets
+
+Social connections require OAuth client_id and client_secret pairs from each identity provider (Google, GitHub, Facebook, etc.). These credentials are stored encrypted in Auth0's configuration store. Treat them as sensitive secrets -- leaking a social provider's client_secret allows impersonation of your application to that provider.
+
+### Database Connections
+
+Database connections store password hashes using bcrypt (10 salt rounds by default). Auth0 never stores plaintext passwords. Custom database connections that delegate to an external user store must use secure HTTPS endpoints for the connection scripts.
+
+### Enterprise Connection Security
+
+- **SAML connections**: Require X.509 certificate configuration for signature validation. SAML assertions are validated against the configured certificate.
+- **OIDC connections**: Validate tokens using the provider's JWKS endpoint. Ensure the provider's discovery document is served over HTTPS.
+- **Azure AD connections**: Use Microsoft's OAuth 2.0 endpoints with tenant-specific configuration. Multi-tenant configurations should restrict to specific Azure AD tenants.
+
+### Brute Force Protection
+
+Database connections support brute force protection, which blocks login attempts after repeated failures. This is configured at the connection level and applies to all clients using the connection.

--- a/apis/org/openmcf/provider/auth0/auth0connection/v1/e2e/profile.yaml
+++ b/apis/org/openmcf/provider/auth0/auth0connection/v1/e2e/profile.yaml
@@ -1,0 +1,11 @@
+apiVersion: qa.openmcf.org/v1
+kind: ComponentE2EProfile
+metadata:
+  name: auth0connection
+spec:
+  tier: 1
+  status: green
+  validated_provisioners:
+    - pulumi
+    - terraform
+  timeout_minutes: 5

--- a/apis/org/openmcf/provider/auth0/auth0connection/v1/e2e/scenarios/minimal.yaml
+++ b/apis/org/openmcf/provider/auth0/auth0connection/v1/e2e/scenarios/minimal.yaml
@@ -1,0 +1,15 @@
+apiVersion: auth0.openmcf.org/v1
+kind: Auth0Connection
+metadata:
+  name: e2e-database
+  org: e2e-org
+  env: testing
+spec:
+  strategy: auth0
+  display_name: E2E Database Connection
+  show_as_button: true
+  database_options:
+    password_policy: good
+    requires_username: false
+    disable_signup: false
+    brute_force_protection: true

--- a/apis/org/openmcf/provider/auth0/auth0connection/v1/iac/tf/main.tf
+++ b/apis/org/openmcf/provider/auth0/auth0connection/v1/iac/tf/main.tf
@@ -54,33 +54,33 @@ resource "auth0_connection" "this" {
     }
 
     # Social connection options (google-oauth2, facebook, github, etc.)
-    client_id     = local.is_social_strategy && local.social_options != null ? local.social_options.client_id : (local.is_oidc_strategy && local.oidc_options != null ? local.oidc_options.client_id : (local.is_waad_strategy && local.azure_ad_options != null ? local.azure_ad_options.client_id : null))
-    client_secret = local.is_social_strategy && local.social_options != null ? local.social_options.client_secret : (local.is_oidc_strategy && local.oidc_options != null ? local.oidc_options.client_secret : (local.is_waad_strategy && local.azure_ad_options != null ? local.azure_ad_options.client_secret : null))
-    scopes        = local.is_social_strategy && local.social_options != null && length(local.social_options.scopes) > 0 ? local.social_options.scopes : (local.is_oidc_strategy && local.oidc_options != null ? local.oidc_options.scopes : null)
+    client_id     = local.is_social_strategy ? try(local.social_options.client_id, null) : (local.is_oidc_strategy ? try(local.oidc_options.client_id, null) : (local.is_waad_strategy ? try(local.azure_ad_options.client_id, null) : null))
+    client_secret = local.is_social_strategy ? try(local.social_options.client_secret, null) : (local.is_oidc_strategy ? try(local.oidc_options.client_secret, null) : (local.is_waad_strategy ? try(local.azure_ad_options.client_secret, null) : null))
+    scopes        = local.is_social_strategy ? try(local.social_options.scopes, null) : (local.is_oidc_strategy ? try(local.oidc_options.scopes, null) : null)
 
     # SAML connection options (samlp strategy)
-    sign_in_endpoint    = local.is_saml_strategy && local.saml_options != null ? local.saml_options.sign_in_endpoint : null
-    signing_cert        = local.is_saml_strategy && local.saml_options != null ? local.saml_options.signing_cert : null
-    sign_out_endpoint   = local.is_saml_strategy && local.saml_options != null ? local.saml_options.sign_out_endpoint : null
-    entity_id           = local.is_saml_strategy && local.saml_options != null ? local.saml_options.entity_id : null
-    protocol_binding    = local.is_saml_strategy && local.saml_options != null ? local.saml_options.protocol_binding : null
-    sign_saml_request   = local.is_saml_strategy && local.saml_options != null ? local.saml_options.sign_request : null
-    signature_algorithm = local.is_saml_strategy && local.saml_options != null ? local.saml_options.signature_algorithm : null
-    digest_algorithm    = local.is_saml_strategy && local.saml_options != null ? local.saml_options.digest_algorithm : null
-    fields_map          = local.is_saml_strategy && local.saml_options != null && length(local.saml_options.attribute_mappings) > 0 ? jsonencode(local.saml_options.attribute_mappings) : null
+    sign_in_endpoint    = local.is_saml_strategy ? try(local.saml_options.sign_in_endpoint, null) : null
+    signing_cert        = local.is_saml_strategy ? try(local.saml_options.signing_cert, null) : null
+    sign_out_endpoint   = local.is_saml_strategy ? try(local.saml_options.sign_out_endpoint, null) : null
+    entity_id           = local.is_saml_strategy ? try(local.saml_options.entity_id, null) : null
+    protocol_binding    = local.is_saml_strategy ? try(local.saml_options.protocol_binding, null) : null
+    sign_saml_request   = local.is_saml_strategy ? try(local.saml_options.sign_request, null) : null
+    signature_algorithm = local.is_saml_strategy ? try(local.saml_options.signature_algorithm, null) : null
+    digest_algorithm    = local.is_saml_strategy ? try(local.saml_options.digest_algorithm, null) : null
+    fields_map          = local.is_saml_strategy ? try(length(local.saml_options.attribute_mappings) > 0 ? jsonencode(local.saml_options.attribute_mappings) : null, null) : null
 
     # OIDC connection options (oidc strategy)
-    issuer                 = local.is_oidc_strategy && local.oidc_options != null ? local.oidc_options.issuer : null
-    type                   = local.is_oidc_strategy && local.oidc_options != null ? local.oidc_options.type : null
-    authorization_endpoint = local.is_oidc_strategy && local.oidc_options != null ? local.oidc_options.authorization_endpoint : null
-    token_endpoint         = local.is_oidc_strategy && local.oidc_options != null ? local.oidc_options.token_endpoint : null
-    jwks_uri               = local.is_oidc_strategy && local.oidc_options != null ? local.oidc_options.jwks_uri : null
+    issuer                 = local.is_oidc_strategy ? try(local.oidc_options.issuer, null) : null
+    type                   = local.is_oidc_strategy ? try(local.oidc_options.type, null) : null
+    authorization_endpoint = local.is_oidc_strategy ? try(local.oidc_options.authorization_endpoint, null) : null
+    token_endpoint         = local.is_oidc_strategy ? try(local.oidc_options.token_endpoint, null) : null
+    jwks_uri               = local.is_oidc_strategy ? try(local.oidc_options.jwks_uri, null) : null
 
     # Azure AD connection options (waad strategy)
-    domain                = local.is_waad_strategy && local.azure_ad_options != null ? local.azure_ad_options.domain : null
-    tenant_domain         = local.is_waad_strategy && local.azure_ad_options != null ? local.azure_ad_options.tenant_id : null
-    max_groups_to_retrieve = local.is_waad_strategy && local.azure_ad_options != null ? tostring(local.azure_ad_options.max_groups_to_retrieve) : null
-    api_enable_users      = local.is_waad_strategy && local.azure_ad_options != null ? local.azure_ad_options.api_enable_users : null
+    domain                 = local.is_waad_strategy ? try(local.azure_ad_options.domain, null) : null
+    tenant_domain          = local.is_waad_strategy ? try(local.azure_ad_options.tenant_id, null) : null
+    max_groups_to_retrieve = local.is_waad_strategy ? try(tostring(local.azure_ad_options.max_groups_to_retrieve), null) : null
+    api_enable_users       = local.is_waad_strategy ? try(local.azure_ad_options.api_enable_users, null) : null
   }
 }
 

--- a/apis/org/openmcf/provider/auth0/auth0connection/v1/iac/tf/provider.tf
+++ b/apis/org/openmcf/provider/auth0/auth0connection/v1/iac/tf/provider.tf
@@ -1,26 +1,3 @@
-# Auth0 Provider Configuration
-# This file configures the Auth0 Terraform provider
-# Documentation: https://registry.terraform.io/providers/auth0/auth0/latest/docs
-
-# Variables for Auth0 authentication
-variable "auth0_credential" {
-  description = "Auth0 API authentication credentials"
-  type = object({
-    # Auth0 tenant domain (e.g., your-tenant.auth0.com or custom domain)
-    domain = string
-
-    # Auth0 Machine-to-Machine application Client ID
-    # Create in Auth0 Dashboard: Applications -> Create Application -> Machine to Machine
-    client_id = string
-
-    # Auth0 Machine-to-Machine application Client Secret
-    # Shown in the application settings after creation
-    client_secret = string
-  })
-  sensitive = true
-}
-
-# Configure the Auth0 Provider
 terraform {
   required_version = ">= 1.0"
 
@@ -30,13 +7,5 @@ terraform {
       version = "~> 1.0"
     }
   }
-}
-
-# Provider configuration
-# The provider uses domain, client_id, and client_secret for API authentication
-provider "auth0" {
-  domain        = var.auth0_credential.domain
-  client_id     = var.auth0_credential.client_id
-  client_secret = var.auth0_credential.client_secret
 }
 

--- a/apis/org/openmcf/provider/auth0/auth0eventstream/v1/docs/compliance.md
+++ b/apis/org/openmcf/provider/auth0/auth0eventstream/v1/docs/compliance.md
@@ -1,0 +1,40 @@
+# Auth0 Event Stream - Compliance
+
+## Regulatory Frameworks
+
+Auth0 supports the following compliance frameworks:
+
+| Framework | Status | Notes |
+|-----------|--------|-------|
+| SOC 2 Type II | Certified | Annual audit cycle |
+| ISO 27001:2022 | Certified | Information security management |
+| ISO 27018:2019 | Certified | PII protection in public clouds |
+| HIPAA | BAA Available | Enterprise plans only |
+| PCI DSS Level 1 | Certified | Service provider certification |
+| FedRAMP Moderate | Authorized | US government workloads |
+| CSA STAR Level 2 | Certified | Cloud security assurance |
+| GDPR | Compliant | Data Processing Agreement available |
+| CCPA | Compliant | California consumer privacy |
+| Privacy Shield | Historical | Deprecated framework, replaced by SCCs |
+
+## Event Stream-Specific Compliance Notes
+
+### PII in Event Data
+
+Auth0 log events contain user PII including email addresses, IP addresses, and user agent strings. When streaming events to external systems, ensure the destination complies with applicable data protection regulations (GDPR, CCPA). Data Processing Agreements may be required with third-party log aggregation providers.
+
+### Cross-Border Data Transfer
+
+Event streams may deliver data to destinations outside your Auth0 tenant's region. If your tenant is in the EU region and events stream to a US-based service, this constitutes a cross-border data transfer subject to GDPR Chapter V requirements. Use Standard Contractual Clauses (SCCs) or other approved transfer mechanisms.
+
+### Log Retention and Right to Erasure
+
+Auth0's built-in log retention is time-limited. Event streams export logs to external systems where retention policies are independently managed. For GDPR right-to-erasure compliance, ensure your external log storage can identify and delete user-specific log entries upon request.
+
+### Audit Trail
+
+All event stream CRUD operations are recorded in Auth0 tenant logs. Stream delivery status (success/failure) is also logged. These operational logs provide evidence of log pipeline health for compliance audits.
+
+### Data Minimization
+
+Auth0 streams all tenant log event types by default. Event streams support filtering by event type. For compliance-sensitive environments, configure filters to exclude event types containing unnecessary PII.

--- a/apis/org/openmcf/provider/auth0/auth0eventstream/v1/docs/cost.md
+++ b/apis/org/openmcf/provider/auth0/auth0eventstream/v1/docs/cost.md
@@ -1,0 +1,40 @@
+# Auth0 Event Stream - Cost
+
+## Pricing Model
+
+Auth0 pricing is based on Monthly Active Users (MAUs), not on the number of resources created. Event streams (log streams) are free API objects with no per-resource cost.
+
+## Free Tier
+
+The Auth0 Free plan includes:
+
+- 25,000 MAUs
+- 1 tenant
+- Log streams available on all plans
+
+## Cost Impact
+
+Creating, updating, or deleting Auth0 event stream resources has no direct billing impact from Auth0. There is no charge per log stream definition.
+
+The only Auth0 cost driver is the number of monthly active users authenticating through your tenant.
+
+## Downstream Cost Considerations
+
+While Auth0 does not charge for event streams, the destination services may incur costs:
+
+| Destination Type | Cost Consideration |
+|-----------------|-------------------|
+| Webhook (HTTP) | Cost depends on your endpoint's hosting |
+| Amazon EventBridge | EventBridge charges per event published |
+| Datadog | Log ingestion charges apply |
+| Splunk | Log volume-based pricing applies |
+| Sumo Logic | Ingestion-based pricing applies |
+| Azure Event Hubs | Throughput unit pricing applies |
+
+## Event Volume
+
+Event volume scales with authentication activity, not with the number of log streams. Creating multiple streams to the same destination type multiplies the downstream ingestion cost but not the Auth0 cost.
+
+## Log Retention
+
+Auth0's built-in log retention is limited by plan tier (2 days free, 30 days enterprise). Event streams provide a mechanism to export logs to external systems for longer retention without affecting Auth0 costs.

--- a/apis/org/openmcf/provider/auth0/auth0eventstream/v1/docs/permissions.md
+++ b/apis/org/openmcf/provider/auth0/auth0eventstream/v1/docs/permissions.md
@@ -1,0 +1,35 @@
+# Auth0 Event Stream - Permissions
+
+## Management API Scopes
+
+Auth0 event stream (log stream) resources require the following Management API scopes for CRUD operations. These scopes must be granted to the M2M application used for infrastructure automation.
+
+| Operation | Scope | Description |
+|-----------|-------|-------------|
+| Read | `read:log_streams` | List and retrieve event stream configurations |
+| Create | `create:log_streams` | Create new event streams (webhook, EventBridge, etc.) |
+| Update | `update:log_streams` | Modify stream destination, filters, and credentials |
+| Delete | `delete:log_streams` | Remove event streams from the tenant |
+
+## Related Scopes
+
+Event streams deliver tenant log data. These additional scopes relate to the underlying log data:
+
+| Operation | Scope | Description |
+|-----------|-------|-------------|
+| Read logs | `read:logs` | Query tenant logs directly via the Management API |
+| Read log users | `read:logs_users` | Access user-specific log entries |
+
+## Minimum Required Scopes
+
+For basic lifecycle management (create, read, update, delete), the minimum required scopes are:
+
+```
+read:log_streams create:log_streams update:log_streams delete:log_streams
+```
+
+The `read:logs` and `read:logs_users` scopes are not required for managing event streams but may be useful for verifying that events are being generated correctly.
+
+## Credential Sensitivity
+
+Event stream configurations contain destination credentials (webhook tokens, API keys). The `read:log_streams` scope exposes these credentials in API responses. Grant this scope only to trusted automation principals.

--- a/apis/org/openmcf/provider/auth0/auth0eventstream/v1/docs/security.md
+++ b/apis/org/openmcf/provider/auth0/auth0eventstream/v1/docs/security.md
@@ -1,0 +1,55 @@
+# Auth0 Event Stream - Security
+
+## Platform Security Posture
+
+Auth0 maintains the following certifications and security standards:
+
+- SOC 2 Type II (annual audit)
+- ISO 27001, ISO 27018 (privacy controls)
+- HIPAA BAA available on enterprise plans
+- PCI DSS Level 1 Service Provider
+- FedRAMP Authorized (moderate baseline)
+- CSA STAR Level 2
+- GDPR compliant with Data Processing Agreement
+
+## Data Protection
+
+- **Data residency**: US, EU, AU regions
+- **Encryption in transit**: TLS 1.2+
+- **Encryption at rest**: AES-256
+- **Penetration testing**: Annual third-party assessments
+
+## Event Stream-Specific Security Notes
+
+### Webhook Credentials
+
+Webhook-type event streams require authentication tokens or credentials to deliver events to your endpoint. These credentials are:
+
+- Stored encrypted in Auth0's configuration store
+- Sent with each webhook delivery (typically as an Authorization header or custom token)
+- Must be rotated periodically to maintain security posture
+
+### Event Data Content
+
+Auth0 event streams deliver tenant log events that may contain user PII:
+
+- User email addresses and names (in login events)
+- IP addresses and geolocation data
+- User agent strings
+- Authentication method details
+
+Ensure the destination system handles this data in accordance with your data protection obligations.
+
+### Transport Security
+
+- **Webhook endpoints**: Must use HTTPS (TLS 1.2+). Auth0 will not deliver events to HTTP endpoints.
+- **Amazon EventBridge**: Uses AWS's built-in encryption for event delivery.
+- **Third-party integrations** (Datadog, Splunk, etc.): Use each provider's secure ingestion endpoints with API key authentication.
+
+### Delivery Reliability
+
+Auth0 retries failed webhook deliveries with exponential backoff. Failed events are retried for up to 24 hours. If the destination remains unavailable, events are dropped. There is no dead-letter queue for failed deliveries.
+
+### Access to Stream Configuration
+
+Event stream configurations contain sensitive credentials (webhook tokens, API keys). Limit Management API access to `read:log_streams` to minimize exposure of these credentials.

--- a/apis/org/openmcf/provider/auth0/auth0eventstream/v1/e2e/profile.yaml
+++ b/apis/org/openmcf/provider/auth0/auth0eventstream/v1/e2e/profile.yaml
@@ -1,0 +1,11 @@
+apiVersion: qa.openmcf.org/v1
+kind: ComponentE2EProfile
+metadata:
+  name: auth0eventstream
+spec:
+  tier: 1
+  status: green
+  validated_provisioners:
+    - pulumi
+    - terraform
+  timeout_minutes: 5

--- a/apis/org/openmcf/provider/auth0/auth0eventstream/v1/e2e/scenarios/minimal.yaml
+++ b/apis/org/openmcf/provider/auth0/auth0eventstream/v1/e2e/scenarios/minimal.yaml
@@ -1,0 +1,16 @@
+apiVersion: auth0.openmcf.org/v1
+kind: Auth0EventStream
+metadata:
+  name: e2e-webhook-stream
+  org: e2e-org
+  env: testing
+spec:
+  destination_type: webhook
+  subscriptions:
+    - user.created
+    - user.updated
+  webhook_configuration:
+    webhook_endpoint: "https://google.com"
+    webhook_authorization:
+      method: bearer
+      token: "e2e-test-token"

--- a/apis/org/openmcf/provider/auth0/auth0eventstream/v1/iac/hack/manifest.yaml
+++ b/apis/org/openmcf/provider/auth0/auth0eventstream/v1/iac/hack/manifest.yaml
@@ -15,9 +15,8 @@ spec:
   subscriptions:
     - user.created
     - user.updated
-    - authentication.success
   webhook_configuration:
-    webhook_endpoint: "https://webhook.site/test-endpoint"
+    webhook_endpoint: "https://api.planton.ai"
     webhook_authorization:
       method: bearer
       token: "test-token-for-development"

--- a/apis/org/openmcf/provider/auth0/auth0eventstream/v1/iac/tf/provider.tf
+++ b/apis/org/openmcf/provider/auth0/auth0eventstream/v1/iac/tf/provider.tf
@@ -1,26 +1,3 @@
-# Auth0 Provider Configuration
-# This file configures the Auth0 Terraform provider
-# Documentation: https://registry.terraform.io/providers/auth0/auth0/latest/docs
-
-# Variables for Auth0 authentication
-variable "auth0_credential" {
-  description = "Auth0 API authentication credentials"
-  type = object({
-    # Auth0 tenant domain (e.g., your-tenant.auth0.com or custom domain)
-    domain = string
-
-    # Auth0 Machine-to-Machine application Client ID
-    # Create in Auth0 Dashboard: Applications -> Create Application -> Machine to Machine
-    client_id = string
-
-    # Auth0 Machine-to-Machine application Client Secret
-    # Shown in the application settings after creation
-    client_secret = string
-  })
-  sensitive = true
-}
-
-# Configure the Auth0 Provider
 terraform {
   required_version = ">= 1.0"
 
@@ -30,13 +7,5 @@ terraform {
       version = "~> 1.0"
     }
   }
-}
-
-# Provider configuration
-# The provider uses domain, client_id, and client_secret for API authentication
-provider "auth0" {
-  domain        = var.auth0_credential.domain
-  client_id     = var.auth0_credential.client_id
-  client_secret = var.auth0_credential.client_secret
 }
 

--- a/apis/org/openmcf/provider/auth0/auth0resourceserver/v1/docs/compliance.md
+++ b/apis/org/openmcf/provider/auth0/auth0resourceserver/v1/docs/compliance.md
@@ -1,0 +1,36 @@
+# Auth0 Resource Server - Compliance
+
+## Regulatory Frameworks
+
+Auth0 supports the following compliance frameworks:
+
+| Framework | Status | Notes |
+|-----------|--------|-------|
+| SOC 2 Type II | Certified | Annual audit cycle |
+| ISO 27001:2022 | Certified | Information security management |
+| ISO 27018:2019 | Certified | PII protection in public clouds |
+| HIPAA | BAA Available | Enterprise plans only |
+| PCI DSS Level 1 | Certified | Service provider certification |
+| FedRAMP Moderate | Authorized | US government workloads |
+| CSA STAR Level 2 | Certified | Cloud security assurance |
+| GDPR | Compliant | Data Processing Agreement available |
+| CCPA | Compliant | California consumer privacy |
+| Privacy Shield | Historical | Deprecated framework, replaced by SCCs |
+
+## Resource Server-Specific Compliance Notes
+
+### Access Token Content
+
+Access tokens issued for resource servers may contain user identifiers and granted scopes. If your API's access tokens include custom claims with PII (via Actions or Rules), ensure token handling complies with GDPR data minimization principles. Only include claims that the API needs.
+
+### Scope-Based Access Control
+
+Resource server scopes provide the foundation for authorization decisions. For compliance-sensitive workloads, document the mapping between scopes and business-level access rights. Auditors may request evidence that scope assignments follow least-privilege principles.
+
+### Audit Trail
+
+All resource server CRUD operations are logged in Auth0 tenant logs. Token issuance events for each resource server are also logged, providing an audit trail of API access. Log retention depends on plan tier (2 days free, 30 days enterprise).
+
+### API Identifier Stability
+
+The resource server identifier (audience) is immutable after creation. Changing an API's audience requires creating a new resource server. This is relevant for compliance documentation that references specific API identifiers.

--- a/apis/org/openmcf/provider/auth0/auth0resourceserver/v1/docs/cost.md
+++ b/apis/org/openmcf/provider/auth0/auth0resourceserver/v1/docs/cost.md
@@ -1,0 +1,35 @@
+# Auth0 Resource Server - Cost
+
+## Pricing Model
+
+Auth0 pricing is based on Monthly Active Users (MAUs), not on the number of resources created. Resource servers (APIs) are free API objects with no per-resource cost.
+
+## Free Tier
+
+The Auth0 Free plan includes:
+
+- 25,000 MAUs
+- 1 tenant
+- Unlimited resource servers (APIs)
+- Unlimited scopes per resource server
+
+## Cost Impact
+
+Creating, updating, or deleting Auth0 resource server resources has no direct billing impact. There is no charge per API definition or per scope/permission defined.
+
+The only cost driver is the number of monthly active users authenticating through your tenant. API definitions and their associated scopes are purely configuration objects.
+
+## Token Volume Considerations
+
+While resource servers are free to define, the access tokens issued for these APIs consume tenant resources. High-volume API usage patterns should consider:
+
+| Factor | Impact |
+|--------|--------|
+| Token issuance rate | Contributes to tenant rate limits |
+| Token lifetime | Shorter tokens increase issuance frequency |
+| Number of scopes per token | Increases token size but not cost |
+| M2M token grants | Counted against plan M2M token quota |
+
+## Rate Limits
+
+The Auth0 Management API enforces rate limits on resource server operations. Creating or updating resource servers counts against the Management API rate limit (varies by plan tier). This affects automation speed but not cost.

--- a/apis/org/openmcf/provider/auth0/auth0resourceserver/v1/docs/permissions.md
+++ b/apis/org/openmcf/provider/auth0/auth0resourceserver/v1/docs/permissions.md
@@ -1,0 +1,37 @@
+# Auth0 Resource Server - Permissions
+
+## Management API Scopes
+
+Auth0 resource server resources require the following Management API scopes for CRUD operations. These scopes must be granted to the M2M application used for infrastructure automation.
+
+| Operation | Scope | Description |
+|-----------|-------|-------------|
+| Read | `read:resource_servers` | List and retrieve API definitions and their scopes |
+| Create | `create:resource_servers` | Create new APIs with identifier, scopes, and signing config |
+| Update | `update:resource_servers` | Modify API settings, scopes, and token configuration |
+| Delete | `delete:resource_servers` | Remove APIs from the tenant |
+
+## Additional Scopes
+
+Managing client access to resource servers requires client grant scopes:
+
+| Operation | Scope | Description |
+|-----------|-------|-------------|
+| Read grants | `read:client_grants` | List which clients can access this API |
+| Create grants | `create:client_grants` | Grant a client access to this API with specific scopes |
+| Update grants | `update:client_grants` | Modify the scopes a client has for this API |
+| Delete grants | `delete:client_grants` | Revoke a client's access to this API |
+
+## Minimum Required Scopes
+
+For basic lifecycle management (create, read, update, delete), the minimum required scopes are:
+
+```
+read:resource_servers create:resource_servers update:resource_servers delete:resource_servers
+```
+
+If the automation also manages which clients can access the API, add:
+
+```
+read:client_grants create:client_grants update:client_grants delete:client_grants
+```

--- a/apis/org/openmcf/provider/auth0/auth0resourceserver/v1/docs/security.md
+++ b/apis/org/openmcf/provider/auth0/auth0resourceserver/v1/docs/security.md
@@ -1,0 +1,48 @@
+# Auth0 Resource Server - Security
+
+## Platform Security Posture
+
+Auth0 maintains the following certifications and security standards:
+
+- SOC 2 Type II (annual audit)
+- ISO 27001, ISO 27018 (privacy controls)
+- HIPAA BAA available on enterprise plans
+- PCI DSS Level 1 Service Provider
+- FedRAMP Authorized (moderate baseline)
+- CSA STAR Level 2
+- GDPR compliant with Data Processing Agreement
+
+## Data Protection
+
+- **Data residency**: US, EU, AU regions
+- **Encryption in transit**: TLS 1.2+
+- **Encryption at rest**: AES-256
+- **Penetration testing**: Annual third-party assessments
+
+## Resource Server-Specific Security Notes
+
+### Signing Algorithms
+
+Resource servers support two token signing algorithms with different security characteristics:
+
+- **RS256 (recommended)**: Asymmetric signing using RSA public/private key pairs. The API validates tokens using Auth0's public JWKS endpoint. No shared secret required. Supports key rotation without coordination.
+- **HS256**: Symmetric signing using a shared secret. The API must store the signing secret to validate tokens. Key rotation requires coordinated updates between Auth0 and all consuming APIs.
+
+Use RS256 unless you have a specific requirement for HS256. The signing secret for HS256 resource servers is sensitive and must be treated as a credential.
+
+### Scope Design
+
+Scopes define the permissions available for an API. Follow least-privilege principles:
+
+- Define granular scopes (e.g., `read:orders`, `write:orders`) rather than coarse ones (`admin`).
+- Scope names are arbitrary strings but conventionally use `action:resource` format.
+- Scopes are requested at authentication time and granted based on client grants or user consent.
+
+### Token Validation
+
+APIs must validate access tokens on every request. Validation must include:
+
+- Signature verification against Auth0's JWKS endpoint (RS256) or shared secret (HS256)
+- Issuer (`iss`) claim matches your Auth0 domain
+- Audience (`aud`) claim matches the resource server identifier
+- Expiration (`exp`) claim is in the future

--- a/apis/org/openmcf/provider/auth0/auth0resourceserver/v1/e2e/profile.yaml
+++ b/apis/org/openmcf/provider/auth0/auth0resourceserver/v1/e2e/profile.yaml
@@ -1,0 +1,11 @@
+apiVersion: qa.openmcf.org/v1
+kind: ComponentE2EProfile
+metadata:
+  name: auth0resourceserver
+spec:
+  tier: 1
+  status: green
+  validated_provisioners:
+    - pulumi
+    - terraform
+  timeout_minutes: 5

--- a/apis/org/openmcf/provider/auth0/auth0resourceserver/v1/e2e/scenarios/minimal.yaml
+++ b/apis/org/openmcf/provider/auth0/auth0resourceserver/v1/e2e/scenarios/minimal.yaml
@@ -1,0 +1,20 @@
+apiVersion: auth0.openmcf.org/v1
+kind: Auth0ResourceServer
+metadata:
+  name: e2e-api
+  org: e2e-org
+  env: testing
+spec:
+  identifier: https://e2e-api.openmcf.org/
+  name: E2E Test API
+  signing_alg: RS256
+  token_lifetime: 86400
+  allow_offline_access: true
+  skip_consent_for_verifiable_first_party_clients: true
+  enforce_policies: true
+  token_dialect: access_token_authz
+  scopes:
+    - name: read:items
+      description: Read access to items
+    - name: write:items
+      description: Write access to items

--- a/apis/org/openmcf/provider/auth0/auth0resourceserver/v1/iac/tf/provider.tf
+++ b/apis/org/openmcf/provider/auth0/auth0resourceserver/v1/iac/tf/provider.tf
@@ -1,20 +1,10 @@
-# Auth0ResourceServer Provider Configuration
-# This file configures the Auth0 provider for Terraform
-
 terraform {
   required_version = ">= 1.0"
 
   required_providers {
     auth0 = {
       source  = "auth0/auth0"
-      version = ">= 1.0"
+      version = "~> 1.0"
     }
   }
 }
-
-# Note: Provider configuration is expected to be set via environment variables:
-# - AUTH0_DOMAIN
-# - AUTH0_CLIENT_ID
-# - AUTH0_CLIENT_SECRET
-#
-# Or passed via provider configuration in the root module.

--- a/e2e/auth0/auth0_test.go
+++ b/e2e/auth0/auth0_test.go
@@ -1,0 +1,174 @@
+//go:build e2e
+
+package auth0
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+	auth0e2e "github.com/plantonhq/openmcf/apis/org/openmcf/provider/auth0/aa_e2e"
+	"github.com/plantonhq/openmcf/e2e/framework/discovery"
+	"github.com/plantonhq/openmcf/e2e/framework/provider"
+	"github.com/plantonhq/openmcf/e2e/framework/runner"
+)
+
+var (
+	testHarness      *auth0e2e.Harness
+	repoRoot         string
+	runID            string
+	pulumiBackendURL string
+)
+
+func TestMain(m *testing.M) {
+	var err error
+	repoRoot, err = filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to resolve repo root: %v\n", err)
+		os.Exit(1)
+	}
+
+	runID = uuid.New().String()[:8]
+
+	backendDir, err := os.MkdirTemp("", "openmcf-e2e-auth0-pulumi-*")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create temp backend dir: %v\n", err)
+		os.Exit(1)
+	}
+	pulumiBackendURL = "file://" + backendDir
+	defer os.RemoveAll(backendDir)
+
+	if err := runner.PulumiLogin(pulumiBackendURL); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to login to pulumi backend: %v\n", err)
+		os.Exit(1)
+	}
+
+	testHarness = auth0e2e.NewHarness()
+	ctx := context.Background()
+	if err := testHarness.Setup(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to setup Auth0 harness: %v\n", err)
+		os.Exit(1)
+	}
+
+	code := m.Run()
+
+	if err := testHarness.Teardown(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to teardown Auth0 harness: %v\n", err)
+	}
+
+	os.Exit(code)
+}
+
+// --- Auth0 Client ---
+
+func TestAuth0Client_Pulumi(t *testing.T)    { runAllScenariosForComponent(t, "auth0client", "pulumi") }
+func TestAuth0Client_Terraform(t *testing.T) { runAllScenariosForComponent(t, "auth0client", "terraform") }
+
+// --- Auth0 Connection ---
+
+func TestAuth0Connection_Pulumi(t *testing.T)    { runAllScenariosForComponent(t, "auth0connection", "pulumi") }
+func TestAuth0Connection_Terraform(t *testing.T) { runAllScenariosForComponent(t, "auth0connection", "terraform") }
+
+// --- Auth0 Resource Server ---
+
+func TestAuth0ResourceServer_Pulumi(t *testing.T)    { runAllScenariosForComponent(t, "auth0resourceserver", "pulumi") }
+func TestAuth0ResourceServer_Terraform(t *testing.T) { runAllScenariosForComponent(t, "auth0resourceserver", "terraform") }
+
+// --- Auth0 Action ---
+
+func TestAuth0Action_Pulumi(t *testing.T)    { runAllScenariosForComponent(t, "auth0action", "pulumi") }
+func TestAuth0Action_Terraform(t *testing.T) { runAllScenariosForComponent(t, "auth0action", "terraform") }
+
+// --- Auth0 Event Stream ---
+
+func TestAuth0EventStream_Pulumi(t *testing.T)    { runAllScenariosForComponent(t, "auth0eventstream", "pulumi") }
+func TestAuth0EventStream_Terraform(t *testing.T) { runAllScenariosForComponent(t, "auth0eventstream", "terraform") }
+
+// runAllScenariosForComponent discovers and runs all E2E scenarios for an Auth0 component.
+func runAllScenariosForComponent(t *testing.T, component, engine string) {
+	t.Helper()
+
+	var moduleDir string
+	switch engine {
+	case "pulumi":
+		moduleDir = filepath.Join(repoRoot, "apis", "org", "openmcf", "provider", "auth0", component, "v1", "iac", "pulumi")
+	case "terraform":
+		moduleDir = filepath.Join(repoRoot, "apis", "org", "openmcf", "provider", "auth0", component, "v1", "iac", "tf")
+	default:
+		t.Fatalf("unsupported engine: %s", engine)
+	}
+
+	if !fileExists(moduleDir) {
+		t.Skipf("component %s %s module not found at %s", component, engine, moduleDir)
+	}
+
+	scenarios, err := discovery.DiscoverTestScenarios(repoRoot, "auth0", component)
+	if err != nil {
+		t.Fatalf("failed to discover test scenarios for %s: %v", component, err)
+	}
+
+	if len(scenarios) == 0 {
+		t.Skipf("no test scenarios found for %s", component)
+	}
+
+	t.Logf("Discovered %d scenarios for %s [%s]", len(scenarios), component, engine)
+
+	for _, scenario := range scenarios {
+		scenario := scenario
+		t.Run(scenario.Name, func(t *testing.T) {
+			runSingleScenario(t, component, moduleDir, engine, scenario)
+		})
+	}
+}
+
+func runSingleScenario(t *testing.T, component, moduleDir, engine string, scenario discovery.TestScenario) {
+	t.Helper()
+
+	tc := &provider.ComponentTestContext{
+		Component:    component,
+		Provider:     "auth0",
+		Engine:       engine,
+		ModuleDir:    moduleDir,
+		ManifestPath: scenario.ManifestPath,
+		RepoRoot:     repoRoot,
+		RunID:        runID,
+		T:            t,
+	}
+
+	if engine == "pulumi" {
+		stackName := runner.GenerateStackName(component+"-"+scenario.Name, runID)
+		if len(stackName) > 50 {
+			stackName = stackName[:50]
+		}
+		tc.StackName = stackName
+		tc.BackendURL = pulumiBackendURL
+	}
+
+	ctx := context.Background()
+	result := runner.RunComponentTest(ctx, tc, testHarness)
+
+	for _, phase := range result.Phases {
+		status := "PASS"
+		if !phase.Passed {
+			status = "FAIL"
+		}
+		t.Logf("  %s: %s (%s)", phase.Phase, status, phase.Duration)
+		if phase.Error != nil {
+			t.Logf("    Error: %v", phase.Error)
+		}
+	}
+
+	if !result.Passed {
+		t.Fatalf("scenario %s/%s [%s] failed (total: %s)", component, scenario.Name, engine, result.Duration)
+	}
+
+	t.Logf("scenario %s/%s [%s] passed (total: %s)", component, scenario.Name, engine, result.Duration)
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/e2e/framework/provider/provider.go
+++ b/e2e/framework/provider/provider.go
@@ -58,8 +58,17 @@ type ComponentTestContext struct {
 	// StackInputFilePath is the path to the generated stack-input YAML.
 	StackInputFilePath string
 
-	// Outputs holds stack outputs after deployment.
+	// Outputs holds raw stack outputs after deployment (map[string]interface{}).
 	Outputs map[string]interface{}
+
+	// FlatOutputs holds the flattened string-keyed outputs after outputs.Flatten().
+	// Populated during the VERIFY-OUT phase.
+	FlatOutputs map[string]string
+
+	// TransformedOutputs holds the typed StackOutputs proto after outputs.Transform().
+	// Stored as interface{} to avoid importing proto in this package.
+	// The runner package type-asserts to proto.Message when needed.
+	TransformedOutputs interface{}
 
 	// RepoRoot is the absolute path to the openmcf repository root.
 	// Used by the fixture system to discover fixture YAML files.

--- a/e2e/framework/runner/BUILD.bazel
+++ b/e2e/framework/runner/BUILD.bazel
@@ -1,9 +1,10 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "runner",
     srcs = [
         "fixtures.go",
+        "outputs_verifier.go",
         "pulumi.go",
         "runner.go",
         "stackinput.go",
@@ -13,14 +14,30 @@ go_library(
     importpath = "github.com/plantonhq/openmcf/e2e/framework/runner",
     visibility = ["//visibility:public"],
     deps = [
+        "//apis/org/openmcf/shared/cloudresourcekind",
         "//apis/org/openmcf/shared/iac/terraform",
         "//e2e/framework/provider",
         "//internal/manifest",
+        "//pkg/crkreflect",
         "//pkg/iac/stackinput",
         "//pkg/iac/stackinput/providerenvvars",
         "//pkg/iac/tofu/generators",
         "//pkg/iac/tofu/tfbackend",
+        "//pkg/outputs",
         "@com_github_gruntwork_io_terratest//modules/terraform",
         "@com_github_pkg_errors//:errors",
+        "@org_golang_google_protobuf//proto",
+        "@org_golang_google_protobuf//reflect/protoreflect",
+    ],
+)
+
+go_test(
+    name = "runner_test",
+    srcs = [
+        "outputs_verifier_test.go",
+    ],
+    embed = [":runner"],
+    deps = [
+        "//apis/org/openmcf/provider/auth0/auth0resourceserver/v1:auth0resourceserver",
     ],
 )

--- a/e2e/framework/runner/outputs_verifier.go
+++ b/e2e/framework/runner/outputs_verifier.go
@@ -1,0 +1,51 @@
+package runner
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/plantonhq/openmcf/apis/org/openmcf/shared/cloudresourcekind"
+	"github.com/plantonhq/openmcf/pkg/crkreflect"
+	"github.com/plantonhq/openmcf/pkg/outputs"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+// VerifyOutputTransformation validates that raw IaC engine outputs can be
+// correctly transformed into a typed StackOutputs proto message.
+//
+// The pipeline is: resolve kind -> Flatten(raw) -> Transform(kind, flat) -> proto.
+// Returns the populated proto message on success, or an error if any step fails.
+// Unknown output fields are logged as warnings by Transform() but do not cause failure.
+func VerifyOutputTransformation(component string, rawOutputs map[string]interface{}) (proto.Message, map[string]string, error) {
+	kind := crkreflect.KindFromString(component)
+	if kind == cloudresourcekind.CloudResourceKind_unspecified {
+		return nil, nil, errors.Errorf("cannot resolve CloudResourceKind from component name %q", component)
+	}
+
+	flatOutputs := outputs.Flatten(rawOutputs)
+
+	msg, err := outputs.Transform(kind, flatOutputs)
+	if err != nil {
+		return nil, flatOutputs, errors.Wrapf(err, "output transformation failed for %s (kind=%s)", component, kind.String())
+	}
+
+	logTransformationSummary(component, kind, flatOutputs, msg)
+
+	return msg, flatOutputs, nil
+}
+
+// logTransformationSummary prints how many proto fields were populated vs available.
+func logTransformationSummary(component string, kind cloudresourcekind.CloudResourceKind, flatOutputs map[string]string, msg proto.Message) {
+	ref := msg.ProtoReflect()
+	totalFields := ref.Descriptor().Fields().Len()
+
+	populated := 0
+	ref.Range(func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
+		populated++
+		return true
+	})
+
+	fmt.Printf("  [outputs] %s (%s): %d/%d proto fields populated from %d raw outputs\n",
+		component, kind.String(), populated, totalFields, len(flatOutputs))
+}

--- a/e2e/framework/runner/outputs_verifier_test.go
+++ b/e2e/framework/runner/outputs_verifier_test.go
@@ -1,0 +1,116 @@
+package runner
+
+import (
+	"testing"
+
+	auth0resourceserverv1 "github.com/plantonhq/openmcf/apis/org/openmcf/provider/auth0/auth0resourceserver/v1"
+)
+
+func TestVerifyOutputTransformation_Auth0ResourceServer(t *testing.T) {
+	rawOutputs := map[string]interface{}{
+		"id":                     "auth0|abc123",
+		"identifier":             "https://api.example.com",
+		"name":                   "Example API",
+		"signing_alg":            "RS256",
+		"signing_secret":         nil,
+		"token_lifetime":         float64(3600),
+		"token_lifetime_for_web": float64(7200),
+		"allow_offline_access":   true,
+		"skip_consent_for_verifiable_first_party_clients": false,
+		"enforce_policies": true,
+		"token_dialect":    "access_token_authz",
+		"is_system":        false,
+		"client_id":        nil,
+	}
+
+	msg, flatOutputs, err := VerifyOutputTransformation("auth0resourceserver", rawOutputs)
+	if err != nil {
+		t.Fatalf("VerifyOutputTransformation failed: %v", err)
+	}
+
+	if msg == nil {
+		t.Fatal("expected non-nil proto message")
+	}
+
+	if flatOutputs == nil {
+		t.Fatal("expected non-nil flat outputs")
+	}
+
+	typed, ok := msg.(*auth0resourceserverv1.Auth0ResourceServerStackOutputs)
+	if !ok {
+		t.Fatalf("expected *Auth0ResourceServerStackOutputs, got %T", msg)
+	}
+
+	assertField(t, "id", typed.GetId(), "auth0|abc123")
+	assertField(t, "identifier", typed.GetIdentifier(), "https://api.example.com")
+	assertField(t, "name", typed.GetName(), "Example API")
+	assertField(t, "signing_alg", typed.GetSigningAlg(), "RS256")
+	assertField(t, "token_lifetime", typed.GetTokenLifetime(), "3600")
+	assertField(t, "token_lifetime_for_web", typed.GetTokenLifetimeForWeb(), "7200")
+	assertField(t, "allow_offline_access", typed.GetAllowOfflineAccess(), "true")
+	assertField(t, "enforce_policies", typed.GetEnforcePolicies(), "true")
+	assertField(t, "token_dialect", typed.GetTokenDialect(), "access_token_authz")
+	assertField(t, "is_system", typed.GetIsSystem(), "false")
+}
+
+func TestVerifyOutputTransformation_UnknownComponent(t *testing.T) {
+	rawOutputs := map[string]interface{}{"id": "test-123"}
+
+	_, _, err := VerifyOutputTransformation("nonexistent_component_xyz", rawOutputs)
+	if err == nil {
+		t.Fatal("expected error for unknown component, got nil")
+	}
+}
+
+func TestVerifyOutputTransformation_EmptyOutputs(t *testing.T) {
+	rawOutputs := map[string]interface{}{}
+
+	msg, flatOutputs, err := VerifyOutputTransformation("auth0resourceserver", rawOutputs)
+	if err != nil {
+		t.Fatalf("VerifyOutputTransformation failed: %v", err)
+	}
+
+	if msg == nil {
+		t.Fatal("expected non-nil proto message for empty outputs")
+	}
+
+	if len(flatOutputs) != 0 {
+		t.Errorf("expected empty flat outputs, got %d entries", len(flatOutputs))
+	}
+}
+
+func TestVerifyOutputTransformation_FlatOutputsCorrect(t *testing.T) {
+	rawOutputs := map[string]interface{}{
+		"id":             "test-id",
+		"token_lifetime": float64(3600),
+		"is_system":      false,
+	}
+
+	_, flatOutputs, err := VerifyOutputTransformation("auth0resourceserver", rawOutputs)
+	if err != nil {
+		t.Fatalf("VerifyOutputTransformation failed: %v", err)
+	}
+
+	assertFlatEntry(t, flatOutputs, "id", "test-id")
+	assertFlatEntry(t, flatOutputs, "token_lifetime", "3600")
+	assertFlatEntry(t, flatOutputs, "is_system", "false")
+}
+
+func assertField(t *testing.T, fieldName, got, expected string) {
+	t.Helper()
+	if got != expected {
+		t.Errorf("field %s: expected %q, got %q", fieldName, expected, got)
+	}
+}
+
+func assertFlatEntry(t *testing.T, m map[string]string, key, expected string) {
+	t.Helper()
+	val, ok := m[key]
+	if !ok {
+		t.Errorf("expected key %q not found in flat outputs", key)
+		return
+	}
+	if val != expected {
+		t.Errorf("flat output %q: expected %q, got %q", key, expected, val)
+	}
+}

--- a/e2e/framework/runner/runner.go
+++ b/e2e/framework/runner/runner.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -191,26 +192,41 @@ func runVerifyOutputs(tc *provider.ComponentTestContext) error {
 	case "pulumi":
 		outputJSON, err := PulumiStackOutputs(tc.ModuleDir, tc.StackName, tc.BackendURL)
 		if err != nil {
-			return nil
+			return errors.Wrap(err, "failed to retrieve pulumi stack outputs")
 		}
-		_ = outputJSON
-		return nil
+		rawOutputs, parseErr := parsePulumiOutputs(outputJSON)
+		if parseErr != nil {
+			return errors.Wrap(parseErr, "failed to parse pulumi stack outputs JSON")
+		}
+		tc.Outputs = rawOutputs
 
 	case "terraform":
 		opts, ok := tc.TerraformOpts.(*tt.Options)
 		if !ok || opts == nil {
-			return nil
+			return errors.New("terraform options not initialized (runValidate must run first)")
 		}
-		outputs, err := TerraformOutputs(tc.T, opts)
+		rawOutputs, err := TerraformOutputs(tc.T, opts)
 		if err != nil {
-			return nil
+			return errors.Wrap(err, "failed to retrieve terraform outputs")
 		}
-		tc.Outputs = outputs
-		return nil
+		tc.Outputs = rawOutputs
 
 	default:
 		return nil
 	}
+
+	if len(tc.Outputs) == 0 {
+		fmt.Printf("  [outputs] %s: no outputs captured, skipping transformation validation\n", tc.Component)
+		return nil
+	}
+
+	msg, flatOutputs, err := VerifyOutputTransformation(tc.Component, tc.Outputs)
+	if err != nil {
+		return err
+	}
+	tc.FlatOutputs = flatOutputs
+	tc.TransformedOutputs = msg
+	return nil
 }
 
 func runVerifyResources(ctx context.Context, tc *provider.ComponentTestContext, harness provider.Harness) error {
@@ -239,4 +255,17 @@ func runDestroy(tc *provider.ComponentTestContext) error {
 
 func runVerifyCleanup(ctx context.Context, tc *provider.ComponentTestContext, harness provider.Harness) error {
 	return harness.VerifyDestroyed(ctx, tc.Component)
+}
+
+// parsePulumiOutputs converts the JSON string from `pulumi stack output --json`
+// into a map[string]interface{} compatible with tc.Outputs.
+func parsePulumiOutputs(outputJSON string) (map[string]interface{}, error) {
+	if outputJSON == "" {
+		return nil, nil
+	}
+	var raw map[string]interface{}
+	if err := json.Unmarshal([]byte(outputJSON), &raw); err != nil {
+		return nil, err
+	}
+	return raw, nil
 }

--- a/pkg/crkreflect/kind_map_gen.go
+++ b/pkg/crkreflect/kind_map_gen.go
@@ -43,6 +43,7 @@ import (
 	alicloudvpngatewayv1 "github.com/plantonhq/openmcf/apis/org/openmcf/provider/alicloud/alicloudvpngateway/v1"
 	alicloudvswitchv1 "github.com/plantonhq/openmcf/apis/org/openmcf/provider/alicloud/alicloudvswitch/v1"
 	atlasmongodbv1 "github.com/plantonhq/openmcf/apis/org/openmcf/provider/atlas/atlasmongodb/v1"
+	auth0actionv1 "github.com/plantonhq/openmcf/apis/org/openmcf/provider/auth0/auth0action/v1"
 	auth0clientv1 "github.com/plantonhq/openmcf/apis/org/openmcf/provider/auth0/auth0client/v1"
 	auth0connectionv1 "github.com/plantonhq/openmcf/apis/org/openmcf/provider/auth0/auth0connection/v1"
 	auth0eventstreamv1 "github.com/plantonhq/openmcf/apis/org/openmcf/provider/auth0/auth0eventstream/v1"
@@ -431,6 +432,7 @@ var ProviderAtlasMap = map[cloudresourcekind.CloudResourceKind]proto.Message{
 }
 
 var ProviderAuth0Map = map[cloudresourcekind.CloudResourceKind]proto.Message{
+	cloudresourcekind.CloudResourceKind_Auth0Action:         &auth0actionv1.Auth0Action{},
 	cloudresourcekind.CloudResourceKind_Auth0Client:         &auth0clientv1.Auth0Client{},
 	cloudresourcekind.CloudResourceKind_Auth0Connection:     &auth0connectionv1.Auth0Connection{},
 	cloudresourcekind.CloudResourceKind_Auth0EventStream:    &auth0eventstreamv1.Auth0EventStream{},

--- a/pkg/outputs/BUILD.bazel
+++ b/pkg/outputs/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "outputs",
     srcs = [
+        "flatten.go",
         "populate.go",
         "preprocess.go",
         "resolve.go",
@@ -25,6 +26,7 @@ go_library(
 go_test(
     name = "outputs_test",
     srcs = [
+        "flatten_test.go",
         "populate_test.go",
         "preprocess_test.go",
         "resolve_test.go",

--- a/pkg/outputs/BUILD.bazel
+++ b/pkg/outputs/BUILD.bazel
@@ -1,0 +1,44 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "outputs",
+    srcs = [
+        "populate.go",
+        "preprocess.go",
+        "resolve.go",
+        "scalar.go",
+        "transform.go",
+    ],
+    importpath = "github.com/plantonhq/openmcf/pkg/outputs",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//apis/org/openmcf/shared/cloudresourcekind",
+        "//pkg/crkreflect",
+        "@com_github_pkg_errors//:errors",
+        "@com_github_sirupsen_logrus//:logrus",
+        "@org_golang_google_protobuf//encoding/protojson",
+        "@org_golang_google_protobuf//proto",
+        "@org_golang_google_protobuf//reflect/protoreflect",
+    ],
+)
+
+go_test(
+    name = "outputs_test",
+    srcs = [
+        "populate_test.go",
+        "preprocess_test.go",
+        "resolve_test.go",
+        "scalar_test.go",
+        "transform_test.go",
+    ],
+    embed = [":outputs"],
+    deps = [
+        "//apis/org/openmcf/provider/auth0/auth0resourceserver/v1:auth0resourceserver",
+        "//apis/org/openmcf/provider/aws/awsvpc/v1:awsvpc",
+        "//apis/org/openmcf/provider/gcp/gcpdnszone/v1:gcpdnszone",
+        "//apis/org/openmcf/provider/kubernetes/kubernetespostgres/v1:kubernetespostgres",
+        "//apis/org/openmcf/shared/cloudresourcekind",
+        "//pkg/crkreflect",
+        "@org_golang_google_protobuf//reflect/protoreflect",
+    ],
+)

--- a/pkg/outputs/flatten.go
+++ b/pkg/outputs/flatten.go
@@ -1,0 +1,111 @@
+package outputs
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+)
+
+// Flatten converts a map[string]interface{} (as produced by Pulumi's
+// automation API or any JSON-deserialized output map) into a flat
+// map[string]string suitable for the IacStackOutputsPayload wire format.
+//
+// Type coercion rules:
+//   - string: direct copy
+//   - float64: integer formatting when the value has no fractional part
+//     (e.g., 3600 -> "3600"), decimal otherwise (e.g., 3.14 -> "3.14")
+//   - bool: "true" / "false"
+//   - json.Number: string representation
+//   - nil: empty string
+//   - []interface{}: recursive flattening with dot-indexed keys (key.0, key.1, ...)
+//   - map[string]interface{}: recursive dot-path flattening (parent.child = value)
+//
+// This function replaces the lossy ConvertInterfaceMapToStringMap which
+// turned non-string scalars (int, float, bool) into the literal "unknown".
+func Flatten(m map[string]interface{}) map[string]string {
+	result := make(map[string]string)
+	if len(m) == 0 {
+		return result
+	}
+	flattenMap(m, "", result)
+	return result
+}
+
+// flattenMap recursively walks a map and writes dot-path keys into out.
+func flattenMap(m map[string]interface{}, prefix string, out map[string]string) {
+	keys := sortedKeys(m)
+	for _, key := range keys {
+		fullKey := key
+		if prefix != "" {
+			fullKey = prefix + "." + key
+		}
+		flattenValue(fullKey, m[key], out)
+	}
+}
+
+// flattenValue dispatches a single value to the appropriate flattening strategy.
+func flattenValue(key string, val interface{}, out map[string]string) {
+	if val == nil {
+		out[key] = ""
+		return
+	}
+
+	switch v := val.(type) {
+	case string:
+		out[key] = v
+
+	case float64:
+		out[key] = formatFloat64(v)
+
+	case bool:
+		out[key] = strconv.FormatBool(v)
+
+	case json.Number:
+		out[key] = v.String()
+
+	case []interface{}:
+		if len(v) == 0 {
+			out[key] = ""
+			return
+		}
+		for i, item := range v {
+			subKey := fmt.Sprintf("%s.%d", key, i)
+			flattenValue(subKey, item, out)
+		}
+
+	case map[string]interface{}:
+		if len(v) == 0 {
+			out[key] = ""
+			return
+		}
+		flattenMap(v, key, out)
+
+	default:
+		out[key] = fmt.Sprintf("%v", v)
+	}
+}
+
+// formatFloat64 converts a float64 to its most compact string form.
+// Whole numbers (3600.0) are formatted as integers ("3600").
+// Fractional values are formatted without trailing zeros ("3.14").
+func formatFloat64(f float64) string {
+	if math.IsInf(f, 0) || math.IsNaN(f) {
+		return fmt.Sprintf("%v", f)
+	}
+	if f == math.Trunc(f) && !math.IsInf(f, 0) {
+		return strconv.FormatInt(int64(f), 10)
+	}
+	return strconv.FormatFloat(f, 'f', -1, 64)
+}
+
+// sortedKeys returns the keys of a map in sorted order for deterministic output.
+func sortedKeys(m map[string]interface{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/pkg/outputs/flatten_test.go
+++ b/pkg/outputs/flatten_test.go
@@ -1,0 +1,327 @@
+package outputs
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestFlatten_NilMap(t *testing.T) {
+	got := Flatten(nil)
+	if len(got) != 0 {
+		t.Errorf("expected empty map for nil input, got %d entries", len(got))
+	}
+}
+
+func TestFlatten_EmptyMap(t *testing.T) {
+	got := Flatten(map[string]interface{}{})
+	if len(got) != 0 {
+		t.Errorf("expected empty map for empty input, got %d entries", len(got))
+	}
+}
+
+func TestFlatten_StringValues(t *testing.T) {
+	input := map[string]interface{}{
+		"vpc_id":     "vpc-0abc123",
+		"identifier": "https://api.example.com",
+		"name":       "my-resource",
+	}
+	got := Flatten(input)
+
+	assertFlatKey(t, got, "vpc_id", "vpc-0abc123")
+	assertFlatKey(t, got, "identifier", "https://api.example.com")
+	assertFlatKey(t, got, "name", "my-resource")
+	assertFlatLen(t, got, 3)
+}
+
+func TestFlatten_EmptyString(t *testing.T) {
+	got := Flatten(map[string]interface{}{"empty": ""})
+	assertFlatKey(t, got, "empty", "")
+}
+
+func TestFlatten_Float64_WholeNumbers(t *testing.T) {
+	input := map[string]interface{}{
+		"token_lifetime":         float64(3600),
+		"zero":                   float64(0),
+		"negative":               float64(-1),
+		"large":                  float64(86400),
+		"token_lifetime_for_web": float64(7200),
+	}
+	got := Flatten(input)
+
+	assertFlatKey(t, got, "token_lifetime", "3600")
+	assertFlatKey(t, got, "zero", "0")
+	assertFlatKey(t, got, "negative", "-1")
+	assertFlatKey(t, got, "large", "86400")
+	assertFlatKey(t, got, "token_lifetime_for_web", "7200")
+}
+
+func TestFlatten_Float64_Fractional(t *testing.T) {
+	input := map[string]interface{}{
+		"ratio":    float64(3.14),
+		"half":     float64(0.5),
+		"small":    float64(0.001),
+		"neg_frac": float64(-2.5),
+	}
+	got := Flatten(input)
+
+	assertFlatKey(t, got, "ratio", "3.14")
+	assertFlatKey(t, got, "half", "0.5")
+	assertFlatKey(t, got, "small", "0.001")
+	assertFlatKey(t, got, "neg_frac", "-2.5")
+}
+
+func TestFlatten_BoolValues(t *testing.T) {
+	input := map[string]interface{}{
+		"allow_offline_access": true,
+		"is_system":            false,
+		"enforce_policies":     true,
+	}
+	got := Flatten(input)
+
+	assertFlatKey(t, got, "allow_offline_access", "true")
+	assertFlatKey(t, got, "is_system", "false")
+	assertFlatKey(t, got, "enforce_policies", "true")
+}
+
+func TestFlatten_NilValues(t *testing.T) {
+	input := map[string]interface{}{
+		"signing_secret": nil,
+		"client_id":      nil,
+	}
+	got := Flatten(input)
+
+	assertFlatKey(t, got, "signing_secret", "")
+	assertFlatKey(t, got, "client_id", "")
+}
+
+func TestFlatten_JsonNumber(t *testing.T) {
+	input := map[string]interface{}{
+		"count": json.Number("42"),
+		"big":   json.Number("9999999999999999"),
+	}
+	got := Flatten(input)
+
+	assertFlatKey(t, got, "count", "42")
+	assertFlatKey(t, got, "big", "9999999999999999")
+}
+
+func TestFlatten_SliceOfStrings(t *testing.T) {
+	input := map[string]interface{}{
+		"nameservers": []interface{}{
+			"ns-1234.awsdns-56.org",
+			"ns-5678.awsdns-78.co.uk",
+			"ns-9012.awsdns-34.net",
+		},
+	}
+	got := Flatten(input)
+
+	assertFlatKey(t, got, "nameservers.0", "ns-1234.awsdns-56.org")
+	assertFlatKey(t, got, "nameservers.1", "ns-5678.awsdns-78.co.uk")
+	assertFlatKey(t, got, "nameservers.2", "ns-9012.awsdns-34.net")
+	assertFlatLen(t, got, 3)
+}
+
+func TestFlatten_EmptySlice(t *testing.T) {
+	input := map[string]interface{}{
+		"tags": []interface{}{},
+	}
+	got := Flatten(input)
+	assertFlatKey(t, got, "tags", "")
+	assertFlatLen(t, got, 1)
+}
+
+func TestFlatten_SliceOfMixedScalars(t *testing.T) {
+	input := map[string]interface{}{
+		"ports": []interface{}{float64(8080), float64(443), "custom"},
+	}
+	got := Flatten(input)
+
+	assertFlatKey(t, got, "ports.0", "8080")
+	assertFlatKey(t, got, "ports.1", "443")
+	assertFlatKey(t, got, "ports.2", "custom")
+}
+
+func TestFlatten_SliceWithNil(t *testing.T) {
+	input := map[string]interface{}{
+		"items": []interface{}{"a", nil, "c"},
+	}
+	got := Flatten(input)
+
+	assertFlatKey(t, got, "items.0", "a")
+	assertFlatKey(t, got, "items.1", "")
+	assertFlatKey(t, got, "items.2", "c")
+}
+
+func TestFlatten_NestedMap(t *testing.T) {
+	input := map[string]interface{}{
+		"username_secret": map[string]interface{}{
+			"name": "postgres.db-xyz.credentials.username",
+			"key":  "username",
+		},
+	}
+	got := Flatten(input)
+
+	assertFlatKey(t, got, "username_secret.name", "postgres.db-xyz.credentials.username")
+	assertFlatKey(t, got, "username_secret.key", "username")
+	assertFlatLen(t, got, 2)
+}
+
+func TestFlatten_EmptyNestedMap(t *testing.T) {
+	input := map[string]interface{}{
+		"metadata": map[string]interface{}{},
+	}
+	got := Flatten(input)
+	assertFlatKey(t, got, "metadata", "")
+	assertFlatLen(t, got, 1)
+}
+
+func TestFlatten_SliceOfMaps(t *testing.T) {
+	input := map[string]interface{}{
+		"private_subnets": []interface{}{
+			map[string]interface{}{
+				"id":   "subnet-abc",
+				"cidr": "10.0.1.0/24",
+			},
+			map[string]interface{}{
+				"id":   "subnet-def",
+				"cidr": "10.0.2.0/24",
+			},
+		},
+	}
+	got := Flatten(input)
+
+	assertFlatKey(t, got, "private_subnets.0.id", "subnet-abc")
+	assertFlatKey(t, got, "private_subnets.0.cidr", "10.0.1.0/24")
+	assertFlatKey(t, got, "private_subnets.1.id", "subnet-def")
+	assertFlatKey(t, got, "private_subnets.1.cidr", "10.0.2.0/24")
+	assertFlatLen(t, got, 4)
+}
+
+func TestFlatten_DeepNesting(t *testing.T) {
+	input := map[string]interface{}{
+		"private_subnets": []interface{}{
+			map[string]interface{}{
+				"id":   "subnet-abc",
+				"cidr": "10.0.1.0/24",
+				"nat_gateway": map[string]interface{}{
+					"id":        "nat-123",
+					"public_ip": "34.56.78.90",
+				},
+			},
+		},
+	}
+	got := Flatten(input)
+
+	assertFlatKey(t, got, "private_subnets.0.id", "subnet-abc")
+	assertFlatKey(t, got, "private_subnets.0.cidr", "10.0.1.0/24")
+	assertFlatKey(t, got, "private_subnets.0.nat_gateway.id", "nat-123")
+	assertFlatKey(t, got, "private_subnets.0.nat_gateway.public_ip", "34.56.78.90")
+	assertFlatLen(t, got, 4)
+}
+
+func TestFlatten_Auth0ResourceServerOutputs(t *testing.T) {
+	// Simulates the real Auth0ResourceServer Pulumi module output shape.
+	// token_lifetime, allow_offline_access, is_system, etc. are non-string
+	// types that the old converter turned into "unknown".
+	input := map[string]interface{}{
+		"id":                     "auth0|abc123",
+		"identifier":             "https://api.example.com",
+		"name":                   "Example API",
+		"signing_alg":            "RS256",
+		"signing_secret":         nil,
+		"token_lifetime":         float64(3600),
+		"token_lifetime_for_web": float64(7200),
+		"allow_offline_access":   true,
+		"skip_consent_for_verifiable_first_party_clients": false,
+		"enforce_policies": true,
+		"token_dialect":    "access_token_authz",
+		"is_system":        false,
+		"client_id":        nil,
+	}
+	got := Flatten(input)
+
+	assertFlatKey(t, got, "id", "auth0|abc123")
+	assertFlatKey(t, got, "identifier", "https://api.example.com")
+	assertFlatKey(t, got, "name", "Example API")
+	assertFlatKey(t, got, "signing_alg", "RS256")
+	assertFlatKey(t, got, "signing_secret", "")
+	assertFlatKey(t, got, "token_lifetime", "3600")
+	assertFlatKey(t, got, "token_lifetime_for_web", "7200")
+	assertFlatKey(t, got, "allow_offline_access", "true")
+	assertFlatKey(t, got, "skip_consent_for_verifiable_first_party_clients", "false")
+	assertFlatKey(t, got, "enforce_policies", "true")
+	assertFlatKey(t, got, "token_dialect", "access_token_authz")
+	assertFlatKey(t, got, "is_system", "false")
+	assertFlatKey(t, got, "client_id", "")
+	assertFlatLen(t, got, 13)
+}
+
+func TestFlatten_MixedTopLevel(t *testing.T) {
+	input := map[string]interface{}{
+		"vpc_id":       "vpc-123",
+		"cidr_block":   "10.0.0.0/16",
+		"enable_dns":   true,
+		"subnet_count": float64(3),
+		"tags":         nil,
+		"public_subnets": []interface{}{
+			"subnet-aaa",
+			"subnet-bbb",
+		},
+	}
+	got := Flatten(input)
+
+	assertFlatKey(t, got, "vpc_id", "vpc-123")
+	assertFlatKey(t, got, "cidr_block", "10.0.0.0/16")
+	assertFlatKey(t, got, "enable_dns", "true")
+	assertFlatKey(t, got, "subnet_count", "3")
+	assertFlatKey(t, got, "tags", "")
+	assertFlatKey(t, got, "public_subnets.0", "subnet-aaa")
+	assertFlatKey(t, got, "public_subnets.1", "subnet-bbb")
+	assertFlatLen(t, got, 7)
+}
+
+func TestFlatten_Deterministic(t *testing.T) {
+	input := map[string]interface{}{
+		"z_key": "z",
+		"a_key": "a",
+		"m_key": "m",
+	}
+	first := Flatten(input)
+	for i := 0; i < 10; i++ {
+		again := Flatten(input)
+		for k, v := range first {
+			if again[k] != v {
+				t.Fatalf("iteration %d: key %q differs: %q vs %q", i, k, v, again[k])
+			}
+		}
+	}
+}
+
+// assertFlatKey checks that a key exists with the expected value in the flattened map.
+func assertFlatKey(t *testing.T, m map[string]string, key, expected string) {
+	t.Helper()
+	val, ok := m[key]
+	if !ok {
+		t.Errorf("expected key %q not found; available keys: %v", key, flatMapKeys(m))
+		return
+	}
+	if val != expected {
+		t.Errorf("key %q: expected %q, got %q", key, expected, val)
+	}
+}
+
+// assertFlatLen checks the total number of entries in the flattened map.
+func assertFlatLen(t *testing.T, m map[string]string, expected int) {
+	t.Helper()
+	if len(m) != expected {
+		t.Errorf("expected %d entries, got %d; keys: %v", expected, len(m), flatMapKeys(m))
+	}
+}
+
+func flatMapKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/pkg/outputs/populate.go
+++ b/pkg/outputs/populate.go
@@ -1,0 +1,262 @@
+package outputs
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+// indexPattern matches an array index at the end of a field path segment,
+// e.g., "subnets[0]" captures "subnets" and "0".
+var indexPattern = regexp.MustCompile(`^(.+)\[(\d+)]$`)
+
+// populateMessage sets fields on a proto message from a flat map of string
+// key-value pairs. Keys are dot-separated field paths that may include array
+// indices (field[0] or field.0 notation).
+//
+// This is the Go equivalent of Java's StackOutputsMapToProtoLoader.load().
+//
+// Unknown fields are logged as warnings and skipped rather than causing errors,
+// because IaC modules may export outputs that have no corresponding proto field.
+func populateMessage(msg proto.Message, outputs map[string]string) error {
+	ref := msg.ProtoReflect()
+	for key, value := range outputs {
+		parts := strings.Split(key, ".")
+		if err := setFieldRecursively(ref, parts, value, 0); err != nil {
+			log.WithFields(log.Fields{
+				"key":   key,
+				"value": value,
+				"error": err,
+			}).Warn("skipping output field that could not be set")
+		}
+	}
+	return nil
+}
+
+// setFieldRecursively walks a dot-separated field path and sets the leaf value
+// on the proto message. Handles scalar fields, repeated fields (both primitives
+// and messages), map fields, and nested message fields.
+//
+// The function mirrors Java's StackOutputsMapToProtoLoader.setFieldRecursively()
+// with Go-specific protoreflect APIs.
+func setFieldRecursively(
+	msg protoreflect.Message,
+	fieldPath []string,
+	value string,
+	pathIndex int,
+) error {
+	segment := fieldPath[pathIndex]
+
+	// Check for bracket-style array index: "field[N]"
+	fieldName, arrayIdx, hasArrayIdx := parseArrayIndex(segment)
+
+	fd := msg.Descriptor().Fields().ByName(protoreflect.Name(fieldName))
+	if fd == nil {
+		return fmt.Errorf("field %q not found on message %s", fieldName, msg.Descriptor().FullName())
+	}
+
+	if fd.IsMap() {
+		return handleMapField(msg, fd, value)
+	}
+
+	if fd.IsList() {
+		return handleRepeatedField(msg, fd, fieldPath, value, pathIndex, fieldName, arrayIdx, hasArrayIdx)
+	}
+
+	// Singular field
+	isLeaf := pathIndex == len(fieldPath)-1
+
+	if isLeaf {
+		if fd.Kind() == protoreflect.MessageKind {
+			return setMessageFieldFromJSON(msg, fd, value)
+		}
+		v, err := convertScalar(value, fd)
+		if err != nil {
+			return err
+		}
+		msg.Set(fd, v)
+		return nil
+	}
+
+	// Non-leaf: recurse into nested message
+	if fd.Kind() != protoreflect.MessageKind {
+		return fmt.Errorf("field %q is %s, cannot recurse into non-message at path index %d",
+			fieldName, fd.Kind(), pathIndex)
+	}
+	nested := msg.Mutable(fd).Message()
+	return setFieldRecursively(nested, fieldPath, value, pathIndex+1)
+}
+
+// handleRepeatedField handles both repeated primitives (e.g., repeated string)
+// and repeated messages (e.g., repeated SubnetStackOutputs).
+//
+// Supports two index notations:
+//   - Bracket: field[0] — index is in the same path segment
+//   - Dot-separated: field.0 — index is in the next path segment
+func handleRepeatedField(
+	msg protoreflect.Message,
+	fd protoreflect.FieldDescriptor,
+	fieldPath []string,
+	value string,
+	pathIndex int,
+	fieldName string,
+	arrayIdx int,
+	hasArrayIdx bool,
+) error {
+	indexSegmentPos := pathIndex
+
+	if !hasArrayIdx {
+		// Index might be in the next path segment: "field.0" or "field.0.subfield"
+		if pathIndex+1 >= len(fieldPath) {
+			// No index provided. If the value is empty, this represents an empty
+			// repeated field (Terraform/Pulumi emit "field_name: \"\"" for empty arrays).
+			if value == "" {
+				return nil
+			}
+			return fmt.Errorf("repeated field %q: no array index provided", fieldName)
+		}
+		nextSegment := fieldPath[pathIndex+1]
+		idx, err := strconv.Atoi(nextSegment)
+		if err != nil {
+			return fmt.Errorf("repeated field %q: invalid index %q", fieldName, nextSegment)
+		}
+		arrayIdx = idx
+		indexSegmentPos = pathIndex + 1
+	}
+
+	list := msg.Mutable(fd).List()
+	ensureListSize(list, fd, arrayIdx)
+
+	isLeaf := indexSegmentPos == len(fieldPath)-1
+
+	if isLeaf {
+		if fd.Kind() == protoreflect.MessageKind {
+			return setRepeatedMessageFromJSON(list, fd, arrayIdx, value)
+		}
+		v, err := convertScalar(value, fd)
+		if err != nil {
+			return err
+		}
+		list.Set(arrayIdx, v)
+		return nil
+	}
+
+	// Non-leaf: recurse into nested message at this index
+	if fd.Kind() != protoreflect.MessageKind {
+		return fmt.Errorf("repeated field %q: cannot recurse into non-message elements", fieldName)
+	}
+	nested := list.Get(arrayIdx).Message()
+	return setFieldRecursively(nested, fieldPath, value, indexSegmentPos+1)
+}
+
+// handleMapField parses a JSON string into a proto map field.
+// The JSON value is expected to be a JSON object like {"key": "value"}.
+func handleMapField(
+	msg protoreflect.Message,
+	fd protoreflect.FieldDescriptor,
+	jsonValue string,
+) error {
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(jsonValue), &parsed); err != nil {
+		return fmt.Errorf("map field %q: failed to parse JSON: %w", fd.Name(), err)
+	}
+
+	mapField := msg.Mutable(fd).Map()
+	keyFd := fd.MapKey()
+	valueFd := fd.MapValue()
+
+	for k, v := range parsed {
+		mapKey, err := convertScalar(k, keyFd)
+		if err != nil {
+			return fmt.Errorf("map field %q key: %w", fd.Name(), err)
+		}
+
+		valueStr := fmt.Sprintf("%v", v)
+		if valueFd.Kind() == protoreflect.MessageKind {
+			// Nested message map values need JSON marshaling
+			jsonBytes, jsonErr := json.Marshal(v)
+			if jsonErr != nil {
+				return fmt.Errorf("map field %q: failed to marshal value for key %q: %w",
+					fd.Name(), k, jsonErr)
+			}
+			newMsg := mapField.NewValue().Message()
+			umOpts := protojson.UnmarshalOptions{DiscardUnknown: true}
+			if umErr := umOpts.Unmarshal(jsonBytes, newMsg.Interface()); umErr != nil {
+				return fmt.Errorf("map field %q: failed to unmarshal value for key %q: %w",
+					fd.Name(), k, umErr)
+			}
+			mapField.Set(mapKey.MapKey(), protoreflect.ValueOfMessage(newMsg))
+		} else {
+			mapValue, mapErr := convertScalar(valueStr, valueFd)
+			if mapErr != nil {
+				return fmt.Errorf("map field %q value for key %q: %w", fd.Name(), k, mapErr)
+			}
+			mapField.Set(mapKey.MapKey(), mapValue)
+		}
+	}
+	return nil
+}
+
+// setMessageFieldFromJSON parses a JSON string and sets it as a message field.
+// This is the Go equivalent of Java's JsonStringToProtobufMessageMerger.merge().
+func setMessageFieldFromJSON(
+	msg protoreflect.Message,
+	fd protoreflect.FieldDescriptor,
+	jsonValue string,
+) error {
+	nested := msg.Mutable(fd).Message()
+	opts := protojson.UnmarshalOptions{DiscardUnknown: true}
+	if err := opts.Unmarshal([]byte(jsonValue), nested.Interface()); err != nil {
+		return fmt.Errorf("field %q: failed to unmarshal JSON into message: %w", fd.Name(), err)
+	}
+	return nil
+}
+
+// setRepeatedMessageFromJSON parses a JSON string and sets it at an index in a
+// repeated message field.
+func setRepeatedMessageFromJSON(
+	list protoreflect.List,
+	fd protoreflect.FieldDescriptor,
+	index int,
+	jsonValue string,
+) error {
+	elem := list.Get(index).Message().Interface()
+	opts := protojson.UnmarshalOptions{DiscardUnknown: true}
+	if err := opts.Unmarshal([]byte(jsonValue), elem); err != nil {
+		return fmt.Errorf("repeated field %q[%d]: failed to unmarshal JSON: %w",
+			fd.Name(), index, err)
+	}
+	return nil
+}
+
+// ensureListSize pads a repeated field's list with default values so that
+// index is a valid position. For message fields, empty sub-messages are
+// appended. For scalars, zero values are appended.
+func ensureListSize(list protoreflect.List, fd protoreflect.FieldDescriptor, index int) {
+	for list.Len() <= index {
+		if fd.Kind() == protoreflect.MessageKind {
+			list.Append(protoreflect.ValueOfMessage(list.NewElement().Message()))
+		} else {
+			list.Append(list.NewElement())
+		}
+	}
+}
+
+// parseArrayIndex extracts the field name and integer index from a segment
+// like "field[3]". Returns the original segment, -1, and false if no bracket
+// notation is present.
+func parseArrayIndex(segment string) (string, int, bool) {
+	matches := indexPattern.FindStringSubmatch(segment)
+	if matches == nil {
+		return segment, -1, false
+	}
+	idx, _ := strconv.Atoi(matches[2])
+	return matches[1], idx, true
+}

--- a/pkg/outputs/populate_test.go
+++ b/pkg/outputs/populate_test.go
@@ -1,0 +1,205 @@
+//go:build !codegen
+// +build !codegen
+
+package outputs
+
+import (
+	"testing"
+
+	auth0v1 "github.com/plantonhq/openmcf/apis/org/openmcf/provider/auth0/auth0resourceserver/v1"
+	awsvpcv1 "github.com/plantonhq/openmcf/apis/org/openmcf/provider/aws/awsvpc/v1"
+	gcpdnsv1 "github.com/plantonhq/openmcf/apis/org/openmcf/provider/gcp/gcpdnszone/v1"
+	k8spgv1 "github.com/plantonhq/openmcf/apis/org/openmcf/provider/kubernetes/kubernetespostgres/v1"
+)
+
+func TestPopulate_StringFields(t *testing.T) {
+	msg := &auth0v1.Auth0ResourceServerStackOutputs{}
+	outputs := map[string]string{
+		"id":         "abc123",
+		"identifier": "https://api.example.com/",
+		"name":       "Example API",
+	}
+
+	if err := populateMessage(msg, outputs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if msg.GetId() != "abc123" {
+		t.Errorf("id: expected %q, got %q", "abc123", msg.GetId())
+	}
+	if msg.GetIdentifier() != "https://api.example.com/" {
+		t.Errorf("identifier: expected %q, got %q", "https://api.example.com/", msg.GetIdentifier())
+	}
+	if msg.GetName() != "Example API" {
+		t.Errorf("name: expected %q, got %q", "Example API", msg.GetName())
+	}
+}
+
+func TestPopulate_RepeatedString(t *testing.T) {
+	msg := &gcpdnsv1.GcpDnsZoneStackOutputs{}
+	outputs := map[string]string{
+		"zone_id":       "zone-123",
+		"zone_name":     "example-zone",
+		"nameservers.0": "ns-1234.awsdns-56.org",
+		"nameservers.1": "ns-5678.awsdns-78.co.uk",
+		"nameservers.2": "ns-9012.awsdns-34.net",
+	}
+
+	if err := populateMessage(msg, outputs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if msg.GetZoneId() != "zone-123" {
+		t.Errorf("zone_id: expected %q, got %q", "zone-123", msg.GetZoneId())
+	}
+	if len(msg.GetNameservers()) != 3 {
+		t.Fatalf("nameservers: expected 3, got %d", len(msg.GetNameservers()))
+	}
+	if msg.GetNameservers()[0] != "ns-1234.awsdns-56.org" {
+		t.Errorf("nameservers[0]: expected %q, got %q", "ns-1234.awsdns-56.org", msg.GetNameservers()[0])
+	}
+	if msg.GetNameservers()[2] != "ns-9012.awsdns-34.net" {
+		t.Errorf("nameservers[2]: expected %q, got %q", "ns-9012.awsdns-34.net", msg.GetNameservers()[2])
+	}
+}
+
+func TestPopulate_NestedMessageDotPath(t *testing.T) {
+	msg := &k8spgv1.KubernetesPostgresStackOutputs{}
+	outputs := map[string]string{
+		"namespace":            "db-namespace",
+		"service":              "postgres-svc",
+		"username_secret.name": "postgres.db-xyz.credentials",
+		"username_secret.key":  "username",
+		"password_secret.name": "postgres.db-xyz.credentials",
+		"password_secret.key":  "password",
+	}
+
+	if err := populateMessage(msg, outputs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if msg.GetNamespace() != "db-namespace" {
+		t.Errorf("namespace: expected %q, got %q", "db-namespace", msg.GetNamespace())
+	}
+	if msg.GetUsernameSecret() == nil {
+		t.Fatal("username_secret: expected non-nil")
+	}
+	if msg.GetUsernameSecret().GetName() != "postgres.db-xyz.credentials" {
+		t.Errorf("username_secret.name: expected %q, got %q",
+			"postgres.db-xyz.credentials", msg.GetUsernameSecret().GetName())
+	}
+	if msg.GetUsernameSecret().GetKey() != "username" {
+		t.Errorf("username_secret.key: expected %q, got %q",
+			"username", msg.GetUsernameSecret().GetKey())
+	}
+	if msg.GetPasswordSecret().GetKey() != "password" {
+		t.Errorf("password_secret.key: expected %q, got %q",
+			"password", msg.GetPasswordSecret().GetKey())
+	}
+}
+
+func TestPopulate_NestedMessageJSON(t *testing.T) {
+	msg := &k8spgv1.KubernetesPostgresStackOutputs{}
+	outputs := map[string]string{
+		"username_secret": `{"name":"pg-secret","key":"user"}`,
+	}
+
+	if err := populateMessage(msg, outputs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if msg.GetUsernameSecret() == nil {
+		t.Fatal("username_secret: expected non-nil")
+	}
+	if msg.GetUsernameSecret().GetName() != "pg-secret" {
+		t.Errorf("username_secret.name: expected %q, got %q",
+			"pg-secret", msg.GetUsernameSecret().GetName())
+	}
+	if msg.GetUsernameSecret().GetKey() != "user" {
+		t.Errorf("username_secret.key: expected %q, got %q",
+			"user", msg.GetUsernameSecret().GetKey())
+	}
+}
+
+func TestPopulate_RepeatedMessageWithBracketIndex(t *testing.T) {
+	msg := &awsvpcv1.AwsVpcStackOutputs{}
+	outputs := map[string]string{
+		"vpc_id":                  "vpc-abc",
+		"private_subnets[0].id":   "subnet-001",
+		"private_subnets[0].cidr": "10.0.1.0/24",
+		"private_subnets[0].nat_gateway.public_ip": "34.56.78.90",
+		"private_subnets[1].id":                    "subnet-002",
+		"private_subnets[1].cidr":                  "10.0.2.0/24",
+	}
+
+	if err := populateMessage(msg, outputs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if msg.GetVpcId() != "vpc-abc" {
+		t.Errorf("vpc_id: expected %q, got %q", "vpc-abc", msg.GetVpcId())
+	}
+	subnets := msg.GetPrivateSubnets()
+	if len(subnets) != 2 {
+		t.Fatalf("private_subnets: expected 2, got %d", len(subnets))
+	}
+	if subnets[0].GetId() != "subnet-001" {
+		t.Errorf("private_subnets[0].id: expected %q, got %q", "subnet-001", subnets[0].GetId())
+	}
+	if subnets[0].GetCidr() != "10.0.1.0/24" {
+		t.Errorf("private_subnets[0].cidr: expected %q, got %q", "10.0.1.0/24", subnets[0].GetCidr())
+	}
+	if subnets[0].GetNatGateway() == nil {
+		t.Fatal("private_subnets[0].nat_gateway: expected non-nil")
+	}
+	if subnets[0].GetNatGateway().GetPublicIp() != "34.56.78.90" {
+		t.Errorf("private_subnets[0].nat_gateway.public_ip: expected %q, got %q",
+			"34.56.78.90", subnets[0].GetNatGateway().GetPublicIp())
+	}
+	if subnets[1].GetId() != "subnet-002" {
+		t.Errorf("private_subnets[1].id: expected %q, got %q", "subnet-002", subnets[1].GetId())
+	}
+}
+
+func TestPopulate_UnknownFieldSkipped(t *testing.T) {
+	msg := &auth0v1.Auth0ResourceServerStackOutputs{}
+	outputs := map[string]string{
+		"id":                     "abc123",
+		"nonexistent_field":      "should-be-skipped",
+		"another_unknown.nested": "also-skipped",
+	}
+
+	err := populateMessage(msg, outputs)
+	if err != nil {
+		t.Fatalf("expected no error (unknown fields should be skipped), got: %v", err)
+	}
+	if msg.GetId() != "abc123" {
+		t.Errorf("id: expected %q, got %q", "abc123", msg.GetId())
+	}
+}
+
+func TestPopulate_EmptyMap(t *testing.T) {
+	msg := &auth0v1.Auth0ResourceServerStackOutputs{}
+	err := populateMessage(msg, map[string]string{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if msg.GetId() != "" {
+		t.Errorf("expected empty id, got %q", msg.GetId())
+	}
+}
+
+func TestPopulate_EmptyRepeatedField(t *testing.T) {
+	msg := &gcpdnsv1.GcpDnsZoneStackOutputs{}
+	outputs := map[string]string{
+		"nameservers": "",
+	}
+
+	err := populateMessage(msg, outputs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(msg.GetNameservers()) != 0 {
+		t.Errorf("expected empty nameservers, got %d entries", len(msg.GetNameservers()))
+	}
+}

--- a/pkg/outputs/preprocess.go
+++ b/pkg/outputs/preprocess.go
@@ -1,0 +1,25 @@
+package outputs
+
+import "strings"
+
+// preprocessKeys normalizes IaC output map keys to match proto field paths.
+//
+// IaC engines (Terraform/Pulumi) may emit keys with conventions that differ
+// from protobuf field naming. This function applies the same normalization as
+// Java's StackOutputsMapKeyPreprocessor.process():
+//
+//   - ".\[" -> "[" : Remove the dot before square brackets. Terraform uses
+//     "subnets.[0].id" but the dot-path walker expects "subnets[0].id".
+//   - "-" -> "_" : Hyphens to underscores. Proto field names use snake_case;
+//     some IaC outputs use hyphenated names.
+//
+// The original map is not modified; a new map is returned.
+func preprocessKeys(outputs map[string]string) map[string]string {
+	result := make(map[string]string, len(outputs))
+	for key, val := range outputs {
+		normalized := strings.ReplaceAll(key, ".[", "[")
+		normalized = strings.ReplaceAll(normalized, "-", "_")
+		result[normalized] = val
+	}
+	return result
+}

--- a/pkg/outputs/preprocess_test.go
+++ b/pkg/outputs/preprocess_test.go
@@ -1,0 +1,72 @@
+package outputs
+
+import (
+	"testing"
+)
+
+func TestPreprocessKeys_DotBeforeBracket(t *testing.T) {
+	input := map[string]string{
+		"subnets.[0].id":   "subnet-abc",
+		"subnets.[1].cidr": "10.0.0.0/24",
+	}
+	got := preprocessKeys(input)
+
+	assertKey(t, got, "subnets[0].id", "subnet-abc")
+	assertKey(t, got, "subnets[1].cidr", "10.0.0.0/24")
+}
+
+func TestPreprocessKeys_HyphensToUnderscores(t *testing.T) {
+	input := map[string]string{
+		"load-balancer-arn": "arn:aws:elasticloadbalancing:...",
+	}
+	got := preprocessKeys(input)
+
+	assertKey(t, got, "load_balancer_arn", "arn:aws:elasticloadbalancing:...")
+}
+
+func TestPreprocessKeys_Combined(t *testing.T) {
+	input := map[string]string{
+		"private-subnets.[0].nat-gateway.public-ip": "34.56.78.90",
+	}
+	got := preprocessKeys(input)
+
+	assertKey(t, got, "private_subnets[0].nat_gateway.public_ip", "34.56.78.90")
+}
+
+func TestPreprocessKeys_NoChanges(t *testing.T) {
+	input := map[string]string{
+		"vpc_id": "vpc-123",
+		"name":   "test",
+	}
+	got := preprocessKeys(input)
+
+	assertKey(t, got, "vpc_id", "vpc-123")
+	assertKey(t, got, "name", "test")
+}
+
+func TestPreprocessKeys_EmptyMap(t *testing.T) {
+	got := preprocessKeys(map[string]string{})
+	if len(got) != 0 {
+		t.Errorf("expected empty map, got %d entries", len(got))
+	}
+}
+
+func assertKey(t *testing.T, m map[string]string, key, expectedValue string) {
+	t.Helper()
+	val, ok := m[key]
+	if !ok {
+		t.Errorf("expected key %q not found in map; keys: %v", key, mapKeys(m))
+		return
+	}
+	if val != expectedValue {
+		t.Errorf("key %q: expected %q, got %q", key, expectedValue, val)
+	}
+}
+
+func mapKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/pkg/outputs/resolve.go
+++ b/pkg/outputs/resolve.go
@@ -1,0 +1,66 @@
+//go:build !codegen
+// +build !codegen
+
+package outputs
+
+import (
+	"github.com/pkg/errors"
+	"github.com/plantonhq/openmcf/apis/org/openmcf/shared/cloudresourcekind"
+	"github.com/plantonhq/openmcf/pkg/crkreflect"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+const (
+	fieldNameStatus  = "status"
+	fieldNameOutputs = "outputs"
+)
+
+// resolveStackOutputsMessage creates a fresh, empty StackOutputs proto message
+// for the given CloudResourceKind. It works by navigating the top-level API
+// resource message's field path: status -> outputs.
+//
+// The returned message is the concrete generated Go type (e.g.,
+// *auth0resourceserverv1.Auth0ResourceServerStackOutputs), not a dynamicpb
+// message. This works because protoreflect.Message.Mutable() on a generated
+// message creates the correct concrete sub-message type.
+//
+// Returns an error if:
+//   - The kind is not registered in crkreflect.ToMessageMap
+//   - The top-level message does not have a "status" field
+//   - The status message does not have an "outputs" field
+//   - Either field is not a message type
+func resolveStackOutputsMessage(kind cloudresourcekind.CloudResourceKind) (proto.Message, error) {
+	topLevel, err := crkreflect.NewInstance(kind)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create instance for kind %s", kind.String())
+	}
+
+	ref := topLevel.ProtoReflect()
+
+	statusFd := ref.Descriptor().Fields().ByName(protoreflect.Name(fieldNameStatus))
+	if statusFd == nil {
+		return nil, errors.Errorf("kind %s: top-level message %s has no %q field",
+			kind.String(), ref.Descriptor().FullName(), fieldNameStatus)
+	}
+	if statusFd.Kind() != protoreflect.MessageKind {
+		return nil, errors.Errorf("kind %s: field %q is %s, not a message",
+			kind.String(), fieldNameStatus, statusFd.Kind())
+	}
+
+	statusMsg := ref.Mutable(statusFd).Message()
+
+	outputsFd := statusMsg.Descriptor().Fields().ByName(protoreflect.Name(fieldNameOutputs))
+	if outputsFd == nil {
+		return nil, errors.Errorf("kind %s: status message %s has no %q field",
+			kind.String(), statusMsg.Descriptor().FullName(), fieldNameOutputs)
+	}
+	if outputsFd.Kind() != protoreflect.MessageKind {
+		return nil, errors.Errorf("kind %s: field %q is %s, not a message",
+			kind.String(), fieldNameOutputs, outputsFd.Kind())
+	}
+
+	outputsMsg := statusMsg.Mutable(outputsFd).Message()
+
+	return outputsMsg.Interface(), nil
+}

--- a/pkg/outputs/resolve_test.go
+++ b/pkg/outputs/resolve_test.go
@@ -1,0 +1,64 @@
+//go:build !codegen
+// +build !codegen
+
+package outputs
+
+import (
+	"testing"
+
+	"github.com/plantonhq/openmcf/apis/org/openmcf/shared/cloudresourcekind"
+	"github.com/plantonhq/openmcf/pkg/crkreflect"
+)
+
+func TestResolve_ReturnsConcreteType(t *testing.T) {
+	kind := cloudresourcekind.CloudResourceKind_Auth0ResourceServer
+	msg, err := resolveStackOutputsMessage(kind)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if msg == nil {
+		t.Fatal("expected non-nil message")
+	}
+
+	fullName := string(msg.ProtoReflect().Descriptor().FullName())
+	expected := "org.openmcf.provider.auth0.auth0resourceserver.v1.Auth0ResourceServerStackOutputs"
+	if fullName != expected {
+		t.Errorf("expected message type %s, got %s", expected, fullName)
+	}
+}
+
+// TestResolve_AllRegisteredKinds iterates every CloudResourceKind that has a
+// registered top-level message and verifies that StackOutputs resolution
+// succeeds. This catches components that don't follow the status.outputs pattern.
+func TestResolve_AllRegisteredKinds(t *testing.T) {
+	var resolved, skipped, failed int
+
+	for _, kind := range crkreflect.KindsList() {
+		_, instErr := crkreflect.NewInstance(kind)
+		if instErr != nil {
+			skipped++
+			continue
+		}
+
+		_, err := resolveStackOutputsMessage(kind)
+		if err != nil {
+			t.Errorf("kind %s: resolve failed: %v", kind.String(), err)
+			failed++
+			continue
+		}
+		resolved++
+	}
+
+	t.Logf("resolved=%d  skipped=%d  failed=%d", resolved, skipped, failed)
+
+	if failed > 0 {
+		t.Errorf("%d kinds failed StackOutputs resolution", failed)
+	}
+}
+
+func TestResolve_UnknownKind(t *testing.T) {
+	_, err := resolveStackOutputsMessage(cloudresourcekind.CloudResourceKind_unspecified)
+	if err == nil {
+		t.Fatal("expected error for unspecified kind, got nil")
+	}
+}

--- a/pkg/outputs/scalar.go
+++ b/pkg/outputs/scalar.go
@@ -1,0 +1,100 @@
+package outputs
+
+import (
+	"fmt"
+	"strconv"
+
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+// convertScalar converts a string value to a protoreflect.Value matching the
+// target field descriptor's type. This is the Go equivalent of Java's
+// StackOutputsMapToProtoLoader.convertToFieldType().
+//
+// Supported kinds: string, bool, int32, sint32, sfixed32, int64, sint64,
+// sfixed64, uint32, fixed32, uint64, fixed64, float, double, enum.
+//
+// For enum fields, the value is looked up by name first, then by numeric value.
+// Returns an error if the string cannot be parsed into the target type.
+func convertScalar(value string, fd protoreflect.FieldDescriptor) (protoreflect.Value, error) {
+	switch fd.Kind() {
+	case protoreflect.StringKind:
+		return protoreflect.ValueOfString(value), nil
+
+	case protoreflect.BoolKind:
+		b, err := strconv.ParseBool(value)
+		if err != nil {
+			return protoreflect.Value{}, fmt.Errorf("field %s: cannot parse %q as bool: %w",
+				fd.FullName(), value, err)
+		}
+		return protoreflect.ValueOfBool(b), nil
+
+	case protoreflect.Int32Kind, protoreflect.Sint32Kind, protoreflect.Sfixed32Kind:
+		n, err := strconv.ParseInt(value, 10, 32)
+		if err != nil {
+			return protoreflect.Value{}, fmt.Errorf("field %s: cannot parse %q as int32: %w",
+				fd.FullName(), value, err)
+		}
+		return protoreflect.ValueOfInt32(int32(n)), nil
+
+	case protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Sfixed64Kind:
+		n, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return protoreflect.Value{}, fmt.Errorf("field %s: cannot parse %q as int64: %w",
+				fd.FullName(), value, err)
+		}
+		return protoreflect.ValueOfInt64(n), nil
+
+	case protoreflect.Uint32Kind, protoreflect.Fixed32Kind:
+		n, err := strconv.ParseUint(value, 10, 32)
+		if err != nil {
+			return protoreflect.Value{}, fmt.Errorf("field %s: cannot parse %q as uint32: %w",
+				fd.FullName(), value, err)
+		}
+		return protoreflect.ValueOfUint32(uint32(n)), nil
+
+	case protoreflect.Uint64Kind, protoreflect.Fixed64Kind:
+		n, err := strconv.ParseUint(value, 10, 64)
+		if err != nil {
+			return protoreflect.Value{}, fmt.Errorf("field %s: cannot parse %q as uint64: %w",
+				fd.FullName(), value, err)
+		}
+		return protoreflect.ValueOfUint64(n), nil
+
+	case protoreflect.FloatKind:
+		f, err := strconv.ParseFloat(value, 32)
+		if err != nil {
+			return protoreflect.Value{}, fmt.Errorf("field %s: cannot parse %q as float: %w",
+				fd.FullName(), value, err)
+		}
+		return protoreflect.ValueOfFloat32(float32(f)), nil
+
+	case protoreflect.DoubleKind:
+		f, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return protoreflect.Value{}, fmt.Errorf("field %s: cannot parse %q as double: %w",
+				fd.FullName(), value, err)
+		}
+		return protoreflect.ValueOfFloat64(f), nil
+
+	case protoreflect.EnumKind:
+		enumDesc := fd.Enum()
+		// Try lookup by name first, then by numeric value.
+		if ev := enumDesc.Values().ByName(protoreflect.Name(value)); ev != nil {
+			return protoreflect.ValueOfEnum(ev.Number()), nil
+		}
+		n, err := strconv.ParseInt(value, 10, 32)
+		if err != nil {
+			return protoreflect.Value{}, fmt.Errorf("field %s: unknown enum value %q and not a valid number",
+				fd.FullName(), value)
+		}
+		return protoreflect.ValueOfEnum(protoreflect.EnumNumber(n)), nil
+
+	case protoreflect.BytesKind:
+		return protoreflect.ValueOfBytes([]byte(value)), nil
+
+	default:
+		return protoreflect.Value{}, fmt.Errorf("field %s: unsupported scalar kind %s",
+			fd.FullName(), fd.Kind())
+	}
+}

--- a/pkg/outputs/scalar_test.go
+++ b/pkg/outputs/scalar_test.go
@@ -1,0 +1,67 @@
+package outputs
+
+import (
+	"testing"
+
+	auth0v1 "github.com/plantonhq/openmcf/apis/org/openmcf/provider/auth0/auth0resourceserver/v1"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+// getFieldDescriptor is a test helper that looks up a field descriptor by name
+// on a given message descriptor.
+func getFieldDescriptor(t *testing.T, md protoreflect.MessageDescriptor, name string) protoreflect.FieldDescriptor {
+	t.Helper()
+	fd := md.Fields().ByName(protoreflect.Name(name))
+	if fd == nil {
+		t.Fatalf("field %q not found on message %s", name, md.FullName())
+	}
+	return fd
+}
+
+func TestConvertScalar_String(t *testing.T) {
+	md := (&auth0v1.Auth0ResourceServerStackOutputs{}).ProtoReflect().Descriptor()
+	fd := getFieldDescriptor(t, md, "id")
+
+	v, err := convertScalar("abc123", fd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v.String() != "abc123" {
+		t.Errorf("expected \"abc123\", got %q", v.String())
+	}
+}
+
+func TestConvertScalar_Bool_True(t *testing.T) {
+	// Use a synthetic test via protoreflect — create a field-like lookup using
+	// a known bool-typed proto. Since Auth0ResourceServer StackOutputs has only
+	// string fields, we test the conversion function directly with a mock
+	// approach: call with "true" and verify it parses.
+
+	// For now, we test the standalone parsing logic by asserting the function
+	// works for non-string kinds using the auth0 "id" field as a string baseline
+	// and verifying error cases.
+	md := (&auth0v1.Auth0ResourceServerStackOutputs{}).ProtoReflect().Descriptor()
+	fd := getFieldDescriptor(t, md, "id")
+
+	// String field should accept any value
+	v, err := convertScalar("true", fd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v.String() != "true" {
+		t.Errorf("expected \"true\", got %q", v.String())
+	}
+}
+
+func TestConvertScalar_EmptyString(t *testing.T) {
+	md := (&auth0v1.Auth0ResourceServerStackOutputs{}).ProtoReflect().Descriptor()
+	fd := getFieldDescriptor(t, md, "id")
+
+	v, err := convertScalar("", fd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v.String() != "" {
+		t.Errorf("expected empty string, got %q", v.String())
+	}
+}

--- a/pkg/outputs/transform.go
+++ b/pkg/outputs/transform.go
@@ -1,0 +1,54 @@
+//go:build !codegen
+// +build !codegen
+
+// Package outputs transforms flat IaC output maps into typed StackOutputs protos.
+//
+// IaC engines (Terraform and Pulumi) produce outputs as flat map[string]string.
+// Each CloudResourceKind in OpenMCF has a typed StackOutputs proto that defines
+// the expected output fields with their concrete types. This package bridges the
+// two representations using proto reflection, so it works for all 365+ component
+// kinds without per-component code.
+//
+// The public entry point is Transform(). See resolve.go for how the StackOutputs
+// message type is discovered, populate.go for how fields are set, and
+// preprocess.go for key normalization.
+package outputs
+
+import (
+	"github.com/pkg/errors"
+	"github.com/plantonhq/openmcf/apis/org/openmcf/shared/cloudresourcekind"
+	"google.golang.org/protobuf/proto"
+)
+
+// Transform takes a CloudResourceKind and a flat map of IaC outputs (as produced
+// by Terraform/Pulumi runners) and returns a typed StackOutputs proto message
+// populated via proto reflection.
+//
+// The returned message is the concrete generated Go type for the kind's
+// StackOutputs (e.g., *Auth0ResourceServerStackOutputs). Callers that know the
+// expected type can safely type-assert the result.
+//
+// Empty or nil output maps produce an empty (zero-value) StackOutputs message,
+// not an error. Unknown output keys that have no corresponding proto field are
+// logged as warnings and skipped.
+func Transform(
+	kind cloudresourcekind.CloudResourceKind,
+	outputs map[string]string,
+) (proto.Message, error) {
+	msg, err := resolveStackOutputsMessage(kind)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to resolve StackOutputs message for kind %s", kind.String())
+	}
+
+	if len(outputs) == 0 {
+		return msg, nil
+	}
+
+	normalized := preprocessKeys(outputs)
+
+	if err := populateMessage(msg, normalized); err != nil {
+		return nil, errors.Wrapf(err, "failed to populate StackOutputs for kind %s", kind.String())
+	}
+
+	return msg, nil
+}

--- a/pkg/outputs/transform_test.go
+++ b/pkg/outputs/transform_test.go
@@ -1,0 +1,241 @@
+//go:build !codegen
+// +build !codegen
+
+package outputs
+
+import (
+	"testing"
+
+	auth0v1 "github.com/plantonhq/openmcf/apis/org/openmcf/provider/auth0/auth0resourceserver/v1"
+	awsvpcv1 "github.com/plantonhq/openmcf/apis/org/openmcf/provider/aws/awsvpc/v1"
+	gcpdnsv1 "github.com/plantonhq/openmcf/apis/org/openmcf/provider/gcp/gcpdnszone/v1"
+	k8spgv1 "github.com/plantonhq/openmcf/apis/org/openmcf/provider/kubernetes/kubernetespostgres/v1"
+	"github.com/plantonhq/openmcf/apis/org/openmcf/shared/cloudresourcekind"
+)
+
+func TestTransform_Auth0ResourceServer(t *testing.T) {
+	outputs := map[string]string{
+		"id":               "6832a1b0c4e5f7d9e0a1b2c3",
+		"identifier":       "https://api.leftbin.ai/",
+		"name":             "Leftbin OS API",
+		"signing_alg":      "RS256",
+		"token_lifetime":   "86400",
+		"enforce_policies": "true",
+		"token_dialect":    "access_token_authz",
+		"is_system":        "false",
+		"client_id":        "abc123xyz",
+	}
+
+	msg, err := Transform(cloudresourcekind.CloudResourceKind_Auth0ResourceServer, outputs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	typed, ok := msg.(*auth0v1.Auth0ResourceServerStackOutputs)
+	if !ok {
+		t.Fatalf("expected *Auth0ResourceServerStackOutputs, got %T", msg)
+	}
+
+	if typed.GetId() != "6832a1b0c4e5f7d9e0a1b2c3" {
+		t.Errorf("id: expected %q, got %q", "6832a1b0c4e5f7d9e0a1b2c3", typed.GetId())
+	}
+	if typed.GetIdentifier() != "https://api.leftbin.ai/" {
+		t.Errorf("identifier: expected %q, got %q", "https://api.leftbin.ai/", typed.GetIdentifier())
+	}
+	if typed.GetName() != "Leftbin OS API" {
+		t.Errorf("name: expected %q, got %q", "Leftbin OS API", typed.GetName())
+	}
+	if typed.GetSigningAlg() != "RS256" {
+		t.Errorf("signing_alg: expected %q, got %q", "RS256", typed.GetSigningAlg())
+	}
+	if typed.GetTokenLifetime() != "86400" {
+		t.Errorf("token_lifetime: expected %q, got %q", "86400", typed.GetTokenLifetime())
+	}
+	if typed.GetEnforcePolicies() != "true" {
+		t.Errorf("enforce_policies: expected %q, got %q", "true", typed.GetEnforcePolicies())
+	}
+	if typed.GetClientId() != "abc123xyz" {
+		t.Errorf("client_id: expected %q, got %q", "abc123xyz", typed.GetClientId())
+	}
+}
+
+func TestTransform_GcpDnsZone(t *testing.T) {
+	outputs := map[string]string{
+		"zone_id":       "123456789",
+		"zone_name":     "example-zone",
+		"nameservers.0": "ns-cloud-a1.googledomains.com",
+		"nameservers.1": "ns-cloud-a2.googledomains.com",
+		"nameservers.2": "ns-cloud-a3.googledomains.com",
+		"nameservers.3": "ns-cloud-a4.googledomains.com",
+	}
+
+	msg, err := Transform(cloudresourcekind.CloudResourceKind_GcpDnsZone, outputs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	typed, ok := msg.(*gcpdnsv1.GcpDnsZoneStackOutputs)
+	if !ok {
+		t.Fatalf("expected *GcpDnsZoneStackOutputs, got %T", msg)
+	}
+
+	if typed.GetZoneId() != "123456789" {
+		t.Errorf("zone_id: expected %q, got %q", "123456789", typed.GetZoneId())
+	}
+	ns := typed.GetNameservers()
+	if len(ns) != 4 {
+		t.Fatalf("nameservers: expected 4, got %d", len(ns))
+	}
+	if ns[0] != "ns-cloud-a1.googledomains.com" {
+		t.Errorf("nameservers[0]: expected %q, got %q", "ns-cloud-a1.googledomains.com", ns[0])
+	}
+	if ns[3] != "ns-cloud-a4.googledomains.com" {
+		t.Errorf("nameservers[3]: expected %q, got %q", "ns-cloud-a4.googledomains.com", ns[3])
+	}
+}
+
+func TestTransform_AwsVpc(t *testing.T) {
+	outputs := map[string]string{
+		"vpc_id":                                    "vpc-0abc123",
+		"internet_gateway_id":                       "igw-xyz789",
+		"vpc_cidr":                                  "10.0.0.0/16",
+		"private_subnets[0].id":                     "subnet-priv-001",
+		"private_subnets[0].name":                   "private-a",
+		"private_subnets[0].cidr":                   "10.0.1.0/24",
+		"private_subnets[0].nat_gateway.id":         "nat-001",
+		"private_subnets[0].nat_gateway.public_ip":  "34.56.78.90",
+		"private_subnets[0].nat_gateway.private_ip": "10.0.1.5",
+		"private_subnets[1].id":                     "subnet-priv-002",
+		"private_subnets[1].name":                   "private-b",
+		"private_subnets[1].cidr":                   "10.0.2.0/24",
+		"public_subnets[0].id":                      "subnet-pub-001",
+		"public_subnets[0].name":                    "public-a",
+		"public_subnets[0].cidr":                    "10.0.100.0/24",
+	}
+
+	msg, err := Transform(cloudresourcekind.CloudResourceKind_AwsVpc, outputs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	typed, ok := msg.(*awsvpcv1.AwsVpcStackOutputs)
+	if !ok {
+		t.Fatalf("expected *AwsVpcStackOutputs, got %T", msg)
+	}
+
+	if typed.GetVpcId() != "vpc-0abc123" {
+		t.Errorf("vpc_id: expected %q, got %q", "vpc-0abc123", typed.GetVpcId())
+	}
+	if typed.GetVpcCidr() != "10.0.0.0/16" {
+		t.Errorf("vpc_cidr: expected %q, got %q", "10.0.0.0/16", typed.GetVpcCidr())
+	}
+
+	privSubnets := typed.GetPrivateSubnets()
+	if len(privSubnets) != 2 {
+		t.Fatalf("private_subnets: expected 2, got %d", len(privSubnets))
+	}
+	if privSubnets[0].GetId() != "subnet-priv-001" {
+		t.Errorf("private_subnets[0].id: expected %q, got %q", "subnet-priv-001", privSubnets[0].GetId())
+	}
+	if privSubnets[0].GetNatGateway() == nil {
+		t.Fatal("private_subnets[0].nat_gateway: expected non-nil")
+	}
+	if privSubnets[0].GetNatGateway().GetPublicIp() != "34.56.78.90" {
+		t.Errorf("private_subnets[0].nat_gateway.public_ip: expected %q, got %q",
+			"34.56.78.90", privSubnets[0].GetNatGateway().GetPublicIp())
+	}
+
+	pubSubnets := typed.GetPublicSubnets()
+	if len(pubSubnets) != 1 {
+		t.Fatalf("public_subnets: expected 1, got %d", len(pubSubnets))
+	}
+	if pubSubnets[0].GetName() != "public-a" {
+		t.Errorf("public_subnets[0].name: expected %q, got %q", "public-a", pubSubnets[0].GetName())
+	}
+}
+
+func TestTransform_KubernetesPostgres(t *testing.T) {
+	outputs := map[string]string{
+		"namespace":            "db-prod",
+		"service":              "postgres-master",
+		"kube_endpoint":        "postgres-master.db-prod.svc.cluster.local:5432",
+		"external_hostname":    "postgres.example.com",
+		"username_secret.name": "postgres.db-prod.credentials.postgresql.acid.zalan.do",
+		"username_secret.key":  "username",
+		"password_secret.name": "postgres.db-prod.credentials.postgresql.acid.zalan.do",
+		"password_secret.key":  "password",
+	}
+
+	msg, err := Transform(cloudresourcekind.CloudResourceKind_KubernetesPostgres, outputs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	typed, ok := msg.(*k8spgv1.KubernetesPostgresStackOutputs)
+	if !ok {
+		t.Fatalf("expected *KubernetesPostgresStackOutputs, got %T", msg)
+	}
+
+	if typed.GetNamespace() != "db-prod" {
+		t.Errorf("namespace: expected %q, got %q", "db-prod", typed.GetNamespace())
+	}
+	if typed.GetService() != "postgres-master" {
+		t.Errorf("service: expected %q, got %q", "postgres-master", typed.GetService())
+	}
+	if typed.GetUsernameSecret() == nil {
+		t.Fatal("username_secret: expected non-nil")
+	}
+	if typed.GetUsernameSecret().GetName() != "postgres.db-prod.credentials.postgresql.acid.zalan.do" {
+		t.Errorf("username_secret.name: got %q", typed.GetUsernameSecret().GetName())
+	}
+	if typed.GetUsernameSecret().GetKey() != "username" {
+		t.Errorf("username_secret.key: got %q", typed.GetUsernameSecret().GetKey())
+	}
+	if typed.GetPasswordSecret().GetKey() != "password" {
+		t.Errorf("password_secret.key: got %q", typed.GetPasswordSecret().GetKey())
+	}
+}
+
+func TestTransform_EmptyOutputs(t *testing.T) {
+	msg, err := Transform(cloudresourcekind.CloudResourceKind_Auth0ResourceServer, map[string]string{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	typed, ok := msg.(*auth0v1.Auth0ResourceServerStackOutputs)
+	if !ok {
+		t.Fatalf("expected *Auth0ResourceServerStackOutputs, got %T", msg)
+	}
+	if typed.GetId() != "" {
+		t.Errorf("expected empty id, got %q", typed.GetId())
+	}
+}
+
+func TestTransform_UnknownKind(t *testing.T) {
+	_, err := Transform(cloudresourcekind.CloudResourceKind_unspecified, map[string]string{"id": "test"})
+	if err == nil {
+		t.Fatal("expected error for unspecified kind, got nil")
+	}
+}
+
+// TestTransform_KeyPreprocessing verifies that keys with dots-before-brackets
+// and hyphens are normalized before field lookup.
+func TestTransform_KeyPreprocessing(t *testing.T) {
+	outputs := map[string]string{
+		"private_subnets.[0].id": "subnet-001",
+		"vpc_id":                 "vpc-abc",
+	}
+
+	msg, err := Transform(cloudresourcekind.CloudResourceKind_AwsVpc, outputs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	typed := msg.(*awsvpcv1.AwsVpcStackOutputs)
+	if len(typed.GetPrivateSubnets()) != 1 {
+		t.Fatalf("private_subnets: expected 1, got %d", len(typed.GetPrivateSubnets()))
+	}
+	if typed.GetPrivateSubnets()[0].GetId() != "subnet-001" {
+		t.Errorf("private_subnets[0].id: expected %q, got %q",
+			"subnet-001", typed.GetPrivateSubnets()[0].GetId())
+	}
+}


### PR DESCRIPTION
## Summary

- Build Auth0 E2E test automation from scratch: harness, verifiers, scenarios, profiles, CI workflow, catalog docs, and Makefile targets
- All 5 Auth0 components (auth0client, auth0connection, auth0resourceserver, auth0action, auth0eventstream) pass both Pulumi and Terraform E2E tests (10/10 GREEN locally)
- Fixed 7 pre-existing bugs: 4 broken `provider.tf` files, auth0client sensitive output, auth0connection null safety, auth0action kind registration, runner Pulumi output parsing
- Added generic reflection-based output transformer (`pkg/outputs`) with Flatten/Transform/Populate for stack output verification

### Auth0 E2E Harness
- `apis/org/openmcf/provider/auth0/aa_e2e/` -- Management API HTTP client for resource verification (no CLI dependency)
- 5 component verifiers dispatching to Auth0 Management API paths (clients, connections, resource-servers, actions, event-streams)
- Separate `e2e/auth0/` test package with own `TestMain` (no kind cluster dependency)

### CI Workflow (`.github/workflows/e2e-auth0.yaml`)
- **PRs**: build-check only (compile + vet) -- no live Auth0 calls
- **Weekly schedule / manual dispatch**: full 10-test E2E run with JUnit artifacts and Step Summary
- GitHub secrets already configured: `AUTH0_DOMAIN`, `AUTH0_CLIENT_ID`, `AUTH0_CLIENT_SECRET`

### Bug Fixes
- Normalized 4 Auth0 TF `provider.tf` files to env-var-only pattern (matching Kubernetes)
- Added `sensitive = true` to auth0client `signing_keys` output
- Fixed OpenTofu null safety in auth0connection with `try()`
- Registered Auth0Action in `kind_map_gen.go`
- Fixed runner `runVerifyOutputs` to parse Pulumi outputs into `tc.Outputs`

## Test plan
- [ ] `build-check` job passes on this PR (compile + vet)
- [ ] Full E2E run via `workflow_dispatch` on `feat/auth0-e2e-ci` branch
- [ ] All 10 tests GREEN in CI (5 components x 2 engines)