### PR TITLE
fix(cloudflare-r2-bucket)!: deploy on Cloudflare provider v5

### DIFF
--- a/_changelog/2026-06/2026-06-24-203431-cloudflare-r2-bucket-provider-v5.md
+++ b/_changelog/2026-06/2026-06-24-203431-cloudflare-r2-bucket-provider-v5.md
@@ -1,0 +1,46 @@
+# CloudflareR2Bucket on Cloudflare provider v5
+
+**Date**: June 24, 2026
+**Type**: Bug fix / Migration
+**Components**: API Definitions, IaC Modules (OpenTofu + Pulumi), Testing Framework
+
+## Summary
+
+`CloudflareR2Bucket` now deploys cleanly on Cloudflare provider v5 across both IaC
+engines, with tofu<->pulumi parity and stack outputs that match the proto contract.
+The OpenTofu module previously pinned the provider to `~> 4.0` while declaring the
+v5-only `cloudflare_r2_custom_domain`, so every tofu deploy failed schema validation
+with `Invalid resource type`. The module is now on `~> 5.0` (matching the Pulumi
+module, already on `sdk/v6`), and the v5 attribute, enum, and output shapes are
+applied consistently on both engines.
+
+## What changed
+
+- **Provider pin**: OpenTofu module moved to Cloudflare `~> 5.0`.
+- **Custom domain**: `cloudflare_r2_custom_domain` uses the v5 attributes `domain`
+  and `enabled` on both engines.
+- **Location hint**: `CloudflareR2Location` enum values match the provider strings
+  exactly (`auto`, `wnam`, `enam`, `weur`, `eeur`, `apac`, `oc`), so the generated
+  enum is used directly. `auto` is the recommended default and means "no hint" —
+  both engines omit the attribute in that case and let Cloudflare choose the region.
+  `location` is optional (the provider treats it as optional/computed).
+- **Tofu variable shapes**: `location` is typed `optional(string)` and the custom
+  domain `zone_id` is typed `optional(string)` — both match how the manifest is
+  rendered into tfvars (enums as strings; `StringValueOrRef` flattened to a string).
+- **Stack outputs**: both engines emit `bucket_name`, `bucket_url`
+  (`https://<account_id>.r2.cloudflarestorage.com/<bucket>`), and `custom_domain_url`
+  (only when a custom domain is enabled), matching `stack_outputs.proto`.
+
+## Testing
+
+- `make protos`, `go build`, and `go vet` of the component are green.
+- `go test` for the component spec (including location-omitted and region cases),
+  `pkg/outputs` (a new `CloudflareR2Bucket` conformance case), and
+  `pkg/secretcoverage` all pass; `openmcf secret-coverage --check` is green.
+- `tofu init`/`validate`/`plan` succeed on provider v5 against the hack manifest,
+  both with and without a custom domain; a real `apply`/`destroy` was exercised
+  against a sandbox account.
+
+---
+
+**Status**: ✅ Production Ready

--- a/apis/org/openmcf/provider/cloudflare/cloudflarer2bucket/v1/BUILD.bazel
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarer2bucket/v1/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//apis/org/openmcf/provider/cloudflare",
         "//apis/org/openmcf/shared",
         "//apis/org/openmcf/shared/foreignkey/v1:foreignkey",
+        "//apis/org/openmcf/shared/options",
         "@build_buf_gen_go_bufbuild_protovalidate_protocolbuffers_go//buf/validate",
         "@org_golang_google_protobuf//reflect/protoreflect",
         "@org_golang_google_protobuf//runtime/protoimpl",

--- a/apis/org/openmcf/provider/cloudflare/cloudflarer2bucket/v1/README.md
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarer2bucket/v1/README.md
@@ -46,10 +46,10 @@ kind: CloudflareR2Bucket
 metadata:
   name: media-bucket
 spec:
-  bucket_name: my-media-assets
-  account_id: "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6"  # Your Cloudflare account ID (32 hex chars)
-  location: WEUR  # Western Europe
-  public_access: false
+  bucketName: my-media-assets
+  accountId: "0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d"  # Your Cloudflare account ID (32 hex chars)
+  location: weur  # Western Europe
+  publicAccess: false
 ```
 
 This creates an R2 bucket in Western Europe with private access (authentication required).
@@ -58,38 +58,35 @@ This creates an R2 bucket in Western Europe with private access (authentication 
 
 ### Required Fields
 
-- **`bucket_name`** (string): DNS-compatible name (3-63 characters, lowercase alphanumeric + hyphens)
+- **`bucketName`** (string): DNS-compatible name (3-63 characters, lowercase alphanumeric + hyphens)
   - Must be globally unique within your Cloudflare account
   - Example: `my-app-assets`, `user-uploads-prod`
 
-- **`account_id`** (string): Your Cloudflare account ID (exactly 32 hexadecimal characters)
+- **`accountId`** (string): Your Cloudflare account ID (exactly 32 hexadecimal characters)
   - Found in Cloudflare Dashboard → Account Home → Account ID
-  - Example: `a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6`
-
-- **`location`** (enum): Primary region for the bucket (location hint)
-  - `WNAM`: Western North America (US West)
-  - `ENAM`: Eastern North America (US East)
-  - `WEUR`: Western Europe
-  - `EEUR`: Eastern Europe
-  - `APAC`: Asia-Pacific
-  - `OC`: Oceania
+  - Example: `0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d`
 
 ### Optional Fields
 
-- **`public_access`** (bool): Enable public access via r2.dev subdomain - Default: `false`
-  - `true`: Bucket accessible at `https://<bucket-name>.<account-id>.r2.dev`
+- **`location`** (enum): Primary region for the bucket (location hint) - Default: `auto`
+  - `auto`: No hint; Cloudflare selects the optimal region
+  - `wnam`: Western North America (US West)
+  - `enam`: Eastern North America (US East)
+  - `weur`: Western Europe
+  - `eeur`: Eastern Europe
+  - `apac`: Asia-Pacific
+  - `oc`: Oceania
+  - The hint is only honored when the bucket is first created and is best-effort.
+
+- **`publicAccess`** (bool): Expose the bucket via Cloudflare's managed r2.dev public URL - Default: `false`
   - `false`: Bucket requires authentication (API keys or presigned URLs)
-  - **Note**: r2.dev URLs are rate-limited; use custom domains for production public buckets
+  - **Note**: r2.dev URLs are rate-limited; use a custom domain for production public buckets
 
-- **`versioning_enabled`** (bool): Enable object versioning - Default: `false`
-  - **Important**: R2 does not currently support object versioning
-  - This field is present for future compatibility but will be ignored
-
-- **`custom_domain`** (object): Custom domain configuration for the bucket
+- **`customDomain`** (object): Custom domain configuration for the bucket
   - **`enabled`** (bool): Whether to enable custom domain access
-  - **`zone_id`** (StringValueOrRef): Cloudflare Zone ID where the domain exists
-    - Can be a literal value: `zone_id: { value: "..." }`
-    - Or reference a CloudflareDnsZone: `zone_id: { valueFrom: { name: "my-dns-zone" } }`
+  - **`zoneId`** (StringValueOrRef): Cloudflare Zone ID where the domain exists
+    - Can be a literal value: `zoneId: { value: "..." }`
+    - Or reference a CloudflareDnsZone: `zoneId: { valueFrom: { name: "my-dns-zone" } }`
   - **`domain`** (string): Full domain name (e.g., "media.example.com")
 
 ## Common Patterns
@@ -102,10 +99,10 @@ kind: CloudflareR2Bucket
 metadata:
   name: app-data-bucket
 spec:
-  bucket_name: myapp-user-uploads
-  account_id: "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6"
-  location: ENAM  # Eastern North America
-  public_access: false  # Requires authentication
+  bucketName: myapp-user-uploads
+  accountId: "0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d"
+  location: enam  # Eastern North America
+  publicAccess: false  # Requires authentication
 ```
 
 **Access**: Use R2 API keys or presigned URLs in your application.
@@ -118,13 +115,13 @@ kind: CloudflareR2Bucket
 metadata:
   name: cdn-assets
 spec:
-  bucket_name: public-cdn-assets
-  account_id: "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6"
-  location: WEUR  # Western Europe
-  public_access: true  # Enable r2.dev public URL
+  bucketName: public-cdn-assets
+  accountId: "0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d"
+  location: weur  # Western Europe
+  publicAccess: true  # Expose via the managed r2.dev public URL
 ```
 
-**Access**: Objects accessible at `https://public-cdn-assets.<account-id>.r2.dev/<object-key>`
+**Access**: Once the managed public URL is enabled, objects are served from a Cloudflare-assigned `r2.dev` address.
 
 **Production Best Practice**: Use a custom domain instead of r2.dev (see documentation).
 
@@ -140,9 +137,9 @@ kind: CloudflareR2Bucket
 metadata:
   name: assets-us
 spec:
-  bucket_name: myapp-assets-us
-  account_id: "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6"
-  location: ENAM
+  bucketName: myapp-assets-us
+  accountId: "0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d"
+  location: enam
 
 ---
 # EU bucket
@@ -151,9 +148,9 @@ kind: CloudflareR2Bucket
 metadata:
   name: assets-eu
 spec:
-  bucket_name: myapp-assets-eu
-  account_id: "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6"
-  location: WEUR
+  bucketName: myapp-assets-eu
+  accountId: "0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d"
+  location: weur
 ```
 
 Route users to the nearest bucket for optimal latency.
@@ -164,12 +161,13 @@ R2's location hints optimize data placement for performance:
 
 | Location | Region | Best For |
 |----------|--------|----------|
-| **WNAM** | Western North America (US West) | Users in US West Coast, CA, Pacific Northwest |
-| **ENAM** | Eastern North America (US East) | Users in US East Coast, NY, Midwest |
-| **WEUR** | Western Europe | Users in UK, France, Spain, Western EU |
-| **EEUR** | Eastern Europe | Users in Germany, Poland, Eastern EU |
-| **APAC** | Asia-Pacific | Users in Australia, Japan, Singapore, India |
-| **OC** | Oceania | Users in Australia, New Zealand |
+| **auto** | Cloudflare chooses | No strong regional preference |
+| **wnam** | Western North America (US West) | Users in US West Coast, CA, Pacific Northwest |
+| **enam** | Eastern North America (US East) | Users in US East Coast, NY, Midwest |
+| **weur** | Western Europe | Users in UK, France, Spain, Western EU |
+| **eeur** | Eastern Europe | Users in Germany, Poland, Eastern EU |
+| **apac** | Asia-Pacific | Users in Australia, Japan, Singapore, India |
+| **oc** | Oceania | Users in Australia, New Zealand |
 
 **Important**: Location hints are optimization suggestions, not strict geo-fencing. R2 automatically replicates data globally for durability. The hint influences initial placement and caching.
 
@@ -217,10 +215,7 @@ aws s3 cp s3://my-bucket/file.txt ./
 
 ### r2.dev Public URLs (Development)
 
-When `public_access: true`, objects are accessible at:
-```
-https://<bucket-name>.<account-id>.r2.dev/<object-key>
-```
+When `publicAccess: true`, objects are served from a Cloudflare-assigned `r2.dev` address for the bucket.
 
 **Limitations**:
 - Rate-limited (not suitable for high traffic)
@@ -239,12 +234,12 @@ kind: CloudflareR2Bucket
 metadata:
   name: media-bucket
 spec:
-  bucket_name: media-assets
-  account_id: "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6"
-  location: WEUR
-  custom_domain:
+  bucketName: media-assets
+  accountId: "0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d"
+  location: weur
+  customDomain:
     enabled: true
-    zone_id:
+    zoneId:
       value: "f1e2d3c4b5a6978899aabbccddeeff00"  # Your Cloudflare Zone ID
     domain: "media.example.com"
 ```
@@ -253,9 +248,9 @@ Or reference a `CloudflareDnsZone` resource:
 
 ```yaml
 spec:
-  custom_domain:
+  customDomain:
     enabled: true
-    zone_id:
+    zoneId:
       valueFrom:
         name: my-dns-zone  # References CloudflareDnsZone named "my-dns-zone"
     domain: "media.example.com"
@@ -382,7 +377,7 @@ OpenMCF handles creating the R2 bucket via either Pulumi or Terraform:
 
 ## Examples
 
-See [examples.md](./examples.md) for complete, working examples including:
+See the [Common Patterns](#common-patterns) above and the ready-to-use [presets](./presets/) for complete, working examples including:
 - Private buckets for application data
 - Public buckets for CDN/media delivery
 - Multi-region deployment strategies
@@ -403,7 +398,7 @@ See [examples.md](./examples.md) for complete, working examples including:
 
 ## What's Next?
 
-- Explore [examples.md](./examples.md) for complete usage patterns
+- Explore the [presets](./presets/) for complete usage patterns
 - Read [docs/README.md](./docs/README.md) for architectural deep dive
 - Deploy using [iac/pulumi/](./iac/pulumi/) or [iac/tf/](./iac/tf/)
 - Review [R2 API documentation](https://developers.cloudflare.com/r2/)

--- a/apis/org/openmcf/provider/cloudflare/cloudflarer2bucket/v1/catalog-page.md
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarer2bucket/v1/catalog-page.md
@@ -1,13 +1,13 @@
 # Cloudflare R2 Bucket
 
-Deploys a Cloudflare R2 object storage bucket with a configurable location hint and optional custom domain access via an R2 managed domain. The component supports all six R2 location regions and integrates with CloudflareDnsZone for custom domain configuration.
+Deploys a Cloudflare R2 object storage bucket with a configurable location hint and optional custom domain access. The component supports all six R2 location regions and integrates with CloudflareDnsZone for custom domain configuration.
 
 ## What Gets Created
 
 When you deploy a CloudflareR2Bucket resource, OpenMCF provisions:
 
 - **R2 Bucket** — a `cloudflare_r2_bucket` resource in the specified Cloudflare account with the configured location hint
-- **R2 Custom Domain** — created only when `customDomain.enabled` is `true`, attaches a custom domain to the bucket via a `cloudflare_r2_custom_domain` resource so the bucket is accessible at the specified hostname
+- **R2 Custom Domain** — created only when `customDomain.enabled` is `true`, attaches a custom domain to the bucket via a `cloudflare_r2_custom_domain` resource so the bucket is accessible at the specified domain
 
 ## Prerequisites
 
@@ -32,7 +32,7 @@ metadata:
 spec:
   bucketName: my-app-assets
   accountId: 0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d
-  location: WNAM
+  location: wnam
 ```
 
 Deploy:
@@ -51,14 +51,13 @@ This creates an R2 bucket named `my-app-assets` in Western North America with no
 |-------|------|-------------|------------|
 | `bucketName` | `string` | Name of the R2 bucket. Must be DNS-compatible. | 3–63 characters, pattern `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$` |
 | `accountId` | `string` | Cloudflare account ID where the bucket is created. | Exactly 32 hex characters, pattern `^[0-9a-fA-F]{32}$` |
-| `location` | `enum` | Location hint for the bucket's primary storage region. | One of: `auto`, `WNAM`, `ENAM`, `WEUR`, `EEUR`, `APAC`, `OC` |
 
 ### Optional Fields
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `publicAccess` | `bool` | `false` | Expose the bucket via Cloudflare's managed `r2.dev` public URL. Note: this currently requires manual enablement via the Cloudflare Dashboard or API. |
-
+| `location` | `enum` | `auto` | Location hint for the bucket's primary storage region. One of: `auto`, `wnam`, `enam`, `weur`, `eeur`, `apac`, `oc`. `auto` lets Cloudflare choose; the hint is only honored at creation and is best-effort. |
+| `publicAccess` | `bool` | `false` | Expose the bucket via Cloudflare's managed `r2.dev` public URL. |
 | `customDomain.enabled` | `bool` | `false` | Enables custom domain access for the bucket. When `true`, `customDomain.zoneId` and `customDomain.domain` are required. |
 | `customDomain.zoneId` | `string` | — | Cloudflare Zone ID where the custom domain is configured. Can reference a CloudflareDnsZone resource via `valueFrom`. Required when `customDomain.enabled` is `true`. |
 | `customDomain.domain` | `string` | — | Fully qualified domain name for accessing the bucket (e.g., `media.example.com`). Must be within the zone specified by `customDomain.zoneId`. Maximum 253 characters. Required when `customDomain.enabled` is `true`. |
@@ -102,7 +101,7 @@ metadata:
 spec:
   bucketName: prod-media-assets
   accountId: 0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d
-  location: ENAM
+  location: enam
   customDomain:
     enabled: true
     zoneId: a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6
@@ -126,7 +125,7 @@ metadata:
 spec:
   bucketName: prod-static-assets
   accountId: 0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d
-  location: WEUR
+  location: weur
   customDomain:
     enabled: true
     zoneId:

--- a/apis/org/openmcf/provider/cloudflare/cloudflarer2bucket/v1/docs/README.md
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarer2bucket/v1/docs/README.md
@@ -77,7 +77,7 @@ provider "cloudflare" {
 resource "cloudflare_r2_bucket" "media" {
   account_id = var.account_id
   name       = "media-bucket"
-  location   = "WEUR"  # Western Europe
+  location   = "weur"  # Western Europe
 }
 
 # For CORS, use AWS provider pointing at R2
@@ -106,14 +106,14 @@ resource "aws_s3_bucket_cors_configuration" "media_cors" {
 
 ```go
 import (
-    "github.com/pulumi/pulumi-cloudflare/sdk/v5/go/cloudflare"
+    "github.com/pulumi/pulumi-cloudflare/sdk/v6/go/cloudflare"
     "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
 bucket, err := cloudflare.NewR2Bucket(ctx, "media-bucket", &cloudflare.R2BucketArgs{
     AccountId: pulumi.String(accountId),
     Name:      pulumi.String("media-bucket"),
-    Location:  pulumi.String("WEUR"),
+    Location:  pulumi.String("weur"),
 })
 ```
 
@@ -316,7 +316,7 @@ When integrating R2 into OpenMCF's multi-cloud IaC framework, we design the sche
 
 2. **Account ID**: Cloudflare account to create the bucket in. **Required.** (OpenMCF may infer this from provider config, but it must be specified somewhere.)
 
-3. **Region/Location**: Location hint (`WNAM`, `ENAM`, `WEUR`, etc.) for latency optimization. **Recommended.** Default to `auto` (Cloudflare chooses) if unspecified.
+3. **Region/Location**: Location hint (`wnam`, `enam`, `weur`, etc.) for latency optimization. **Recommended.** Default to `auto` (Cloudflare chooses) if unspecified.
 
 4. **Public Access**: Boolean to indicate if the bucket should be publicly accessible. **Common.** If `true`, decide between:
    - `public_dev_url`: Enable `r2.dev` URL (dev/test only)
@@ -342,7 +342,7 @@ When integrating R2 into OpenMCF's multi-cloud IaC framework, we design the sche
 
 ### What We Omit from the Spec
 
-- **Versioning**: R2 doesn't support it. (Note: The current `spec.proto` mistakenly includes `versioning_enabled`—this should be removed.)
+- **Versioning**: R2 doesn't support it, so the spec does not model it.
 - **Bucket Policies / ACLs**: Not applicable to R2.
 - **Static Website Hosting**: Not a bucket-level config in R2 (use Cloudflare Pages/Workers instead).
 
@@ -364,7 +364,7 @@ message CloudflareR2BucketSpec {
   // Cloudflare account ID (32-char hex)
   string account_id = 2;
 
-  // Region/location hint (WNAM, ENAM, WEUR, etc.)
+  // Region/location hint (wnam, enam, weur, etc.; auto = let Cloudflare choose)
   CloudflareR2Location location = 3;
 
   // Enable public access via r2.dev URL (dev/test only)
@@ -384,7 +384,7 @@ message CloudflareR2BucketSpec {
 }
 ```
 
-**Note:** The current `spec.proto` includes `versioning_enabled`, which is not supported by R2. This field should be removed to avoid confusion.
+**Note:** R2 does not support object versioning, so the spec deliberately does not model it.
 
 ### Default Choices
 
@@ -419,7 +419,7 @@ metadata:
 spec:
   bucketName: dev-test-uploads
   account_id: 1234567890abcdef1234567890abcdef
-  location: WNAM
+  location: wnam
   public_access: false
 ```
 
@@ -442,7 +442,7 @@ metadata:
 spec:
   bucketName: staging-assets
   account_id: 1234567890abcdef1234567890abcdef
-  location: WEUR
+  location: weur
   public_access: true
   public_dev_url: true  # Use r2.dev for staging (custom domain not needed yet)
   cors:
@@ -473,7 +473,7 @@ metadata:
 spec:
   bucketName: prod-media
   account_id: 1234567890abcdef1234567890abcdef
-  location: ENAM
+  location: enam
   public_access: true
   custom_domain: media.example.com
   cors:
@@ -509,7 +509,7 @@ metadata:
 spec:
   bucketName: prod-user-data-eu
   account_id: 1234567890abcdef1234567890abcdef
-  location: WEUR
+  location: weur
   jurisdiction: EU  # Enforce data stays within EU
   public_access: false
   lifecycle:

--- a/apis/org/openmcf/provider/cloudflare/cloudflarer2bucket/v1/hack/manifest.yaml
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarer2bucket/v1/hack/manifest.yaml
@@ -1,5 +1,8 @@
 apiVersion: cloudflare.openmcf.org/v1
 kind: CloudflareR2Bucket
 metadata:
-  name: first-certificate
+  name: r2-hack-bucket
 spec:
+  bucketName: openmcf-r2-hack-bucket
+  accountId: 0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d
+  location: weur

--- a/apis/org/openmcf/provider/cloudflare/cloudflarer2bucket/v1/iac/pulumi/README.md
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarer2bucket/v1/iac/pulumi/README.md
@@ -66,11 +66,10 @@ target:
   metadata:
     name: media-bucket
   spec:
-    bucket_name: myapp-media-assets
-    account_id: "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6"  # Your account ID
-    location: 3  # WEUR (Western Europe)
-    public_access: true
-    versioning_enabled: false
+    bucketName: myapp-media-assets
+    accountId: "0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d"  # Your account ID
+    location: weur  # Western Europe
+    publicAccess: true
 
 provider_config:
   # Cloudflare credentials provided via environment variables
@@ -166,12 +165,12 @@ Pulumi will show a diff of changes before applying.
 
 **Change location**:
 ```yaml
-location: 5  # APAC instead of WEUR
+location: apac  # Asia-Pacific instead of weur
 ```
 
 **Enable public access**:
 ```yaml
-public_access: true
+publicAccess: true
 ```
 
 **Note**: Some changes (like bucket name) require bucket replacement (destroy + create).
@@ -357,19 +356,17 @@ pulumi import cloudflare:index/r2Bucket:R2Bucket main <bucket-id>
 
 ### Public Access
 
-The Cloudflare Pulumi provider does not yet expose a direct field for toggling r2.dev public URLs. When `public_access: true` is specified:
-- A warning is logged
-- Public access must be enabled manually via Cloudflare Dashboard or API
+The managed r2.dev public URL has its own lifecycle and is configured outside this module. For production public access, attach a custom domain (`custom_domain`), which this module provisions directly.
 
 ### Versioning
 
-R2 does not support object versioning. The `versioning_enabled` field is ignored with a warning.
+R2 does not support object versioning, so it is not modeled by this component.
 
 ## Additional Resources
 
 - [Pulumi Cloudflare Provider Docs](https://www.pulumi.com/registry/packages/cloudflare/)
 - [Cloudflare R2 API Docs](https://developers.cloudflare.com/api/operations/r2-create-bucket)
-- [overview.md](./overview.md) - Architecture and design decisions
+- [Architecture deep dive](../../docs/README.md) - Architecture and design decisions
 - [Component README](../../README.md) - User-facing component documentation
 
 ## Support

--- a/apis/org/openmcf/provider/cloudflare/cloudflarer2bucket/v1/iac/pulumi/module/bucket.go
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarer2bucket/v1/iac/pulumi/module/bucket.go
@@ -13,34 +13,32 @@ func bucket(
 	cloudflareProvider *cloudflare.Provider,
 ) (*cloudflare.R2Bucket, error) {
 
-	// 1. Get the location string directly from the enum.
-	// The enum values (auto, WNAM, ENAM, etc.) match Cloudflare's expected strings.
-	bucketLocation := locals.CloudflareR2Bucket.Spec.Location.String()
+	// 1. Assemble the bucket arguments. The location hint is omitted when "auto"
+	// (the enum zero value) so Cloudflare selects the region. The enum value
+	// name matches the string the provider expects, so .String() is used directly.
+	bucketArgs := &cloudflare.R2BucketArgs{
+		AccountId: pulumi.String(locals.CloudflareR2Bucket.Spec.AccountId),
+		Name:      pulumi.String(locals.CloudflareR2Bucket.Spec.BucketName),
+	}
+	if locals.CloudflareR2Bucket.Spec.Location != 0 {
+		bucketArgs.Location = pulumi.String(locals.CloudflareR2Bucket.Spec.Location.String())
+	}
 
 	// 2. Create the bucket.
 	createdBucket, err := cloudflare.NewR2Bucket(
 		ctx,
 		"bucket",
-		&cloudflare.R2BucketArgs{
-			AccountId: pulumi.String(locals.CloudflareR2Bucket.Spec.AccountId),
-			Name:      pulumi.String(locals.CloudflareR2Bucket.Spec.BucketName),
-			Location:  pulumi.String(bucketLocation),
-		},
+		bucketArgs,
 		pulumi.Provider(cloudflareProvider),
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create Cloudflare R2 bucket")
 	}
 
-	// 4. Handle public access (r2.dev subdomain).
-	// Note: The Cloudflare Pulumi provider does not yet expose a direct field for toggling
-	// the r2.dev public URL. This currently requires using the Cloudflare API directly
-	// or the dashboard. We log a warning if public_access is requested.
-	if locals.CloudflareR2Bucket.Spec.PublicAccess {
-		ctx.Log.Warn("Public access (r2.dev subdomain) must be enabled manually via Cloudflare Dashboard or API - field noted but not yet implemented in provider.", nil)
-	}
+	// 3. Public access via the managed r2.dev URL has its own lifecycle and is
+	// configured outside this module; the custom domain below is the production path.
 
-	// 5. Handle custom domain configuration.
+	// 4. Handle custom domain configuration.
 	if locals.CloudflareR2Bucket.Spec.CustomDomain != nil && locals.CloudflareR2Bucket.Spec.CustomDomain.Enabled {
 		customDomain := locals.CloudflareR2Bucket.Spec.CustomDomain
 		zoneId := customDomain.ZoneId.GetValue()
@@ -60,8 +58,13 @@ func bucket(
 		ctx.Export(OpCustomDomainUrl, pulumi.Sprintf("https://%s", customDomain.Domain))
 	}
 
-	// 7. Export stack outputs.
+	// 5. Export stack outputs.
 	ctx.Export(OpBucketName, createdBucket.Name)
+	ctx.Export(OpBucketUrl, pulumi.Sprintf(
+		"https://%s.r2.cloudflarestorage.com/%s",
+		locals.CloudflareR2Bucket.Spec.AccountId,
+		locals.CloudflareR2Bucket.Spec.BucketName,
+	))
 
 	return createdBucket, nil
 }

--- a/apis/org/openmcf/provider/cloudflare/cloudflarer2bucket/v1/iac/tf/README.md
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarer2bucket/v1/iac/tf/README.md
@@ -57,7 +57,7 @@ terraform {
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }
@@ -78,11 +78,10 @@ module "r2_bucket" {
   }
 
   spec = {
-    bucket_name        = "myapp-media-assets"
-    account_id         = "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6"  # Your account ID
-    location           = 3  # WEUR (Western Europe)
-    public_access      = true
-    versioning_enabled = false
+    bucket_name   = "myapp-media-assets"
+    account_id    = "0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d"  # Your account ID
+    location      = "weur"  # Western Europe
+    public_access = true
   }
 }
 
@@ -116,8 +115,8 @@ Terraform will perform the following actions:
   + resource "cloudflare_r2_bucket" "main" {
       + id         = (known after apply)
       + name       = "myapp-media-assets"
-      + account_id = "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6"
-      + location   = "WEUR"
+      + account_id = "0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d"
+      + location   = "weur"
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -170,43 +169,37 @@ R2 bucket specification.
 
 - **`account_id`** (string): Cloudflare account ID (32 hex characters)
   ```hcl
-  account_id = "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6"
-  ```
-
-- **`location`** (number): Primary region for the bucket
-  - `0` = auto (unspecified)
-  - `1` = WNAM (Western North America)
-  - `2` = ENAM (Eastern North America)
-  - `3` = WEUR (Western Europe)
-  - `4` = EEUR (Eastern Europe)
-  - `5` = APAC (Asia-Pacific)
-  - `6` = OC (Oceania)
-  ```hcl
-  location = 3  # WEUR
+  account_id = "0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d"
   ```
 
 **Optional fields**:
 
-- **`public_access`** (bool): Enable public access via r2.dev subdomain - Default: `false`
+- **`location`** (string): Primary region for the bucket (location hint) - Default: `auto`
+  - `auto` = no hint; Cloudflare selects the optimal region
+  - `wnam` = Western North America
+  - `enam` = Eastern North America
+  - `weur` = Western Europe
+  - `eeur` = Eastern Europe
+  - `apac` = Asia-Pacific
+  - `oc` = Oceania
+  ```hcl
+  location = "weur"
+  ```
+  When `auto` (or omitted), the hint is not sent and Cloudflare chooses the region.
+
+- **`public_access`** (bool): Expose the bucket via the managed r2.dev public URL - Default: `false`
   ```hcl
   public_access = true
   ```
-  **Note**: Terraform provider doesn't yet support toggling this. Must enable manually via Dashboard.
-
-- **`versioning_enabled`** (bool): Enable object versioning - Default: `false`
-  ```hcl
-  versioning_enabled = false
-  ```
-  **Note**: R2 does not support versioning. This field is ignored.
+  **Note**: The managed r2.dev URL has its own lifecycle and is configured outside this module; use a custom domain for production.
 
 ## Outputs
 
 | Output | Type | Description |
 |--------|------|-------------|
 | `bucket_name` | string | The name of the R2 bucket |
-| `bucket_id` | string | The ID of the R2 bucket |
-| `account_id` | string | The Cloudflare account ID |
-| `location` | string | The location hint for the bucket |
+| `bucket_url` | string | The path-style S3 API URL for the bucket |
+| `custom_domain_url` | string | The custom domain URL when `custom_domain.enabled` is `true` |
 
 Access outputs:
 
@@ -242,8 +235,8 @@ module "private_bucket" {
 
   spec = {
     bucket_name  = "myapp-private-data"
-    account_id   = "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6"
-    location     = 2  # ENAM
+    account_id   = "0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d"
+    location     = "enam"  # Eastern North America
     public_access = false
   }
 }
@@ -261,8 +254,8 @@ module "cdn_bucket" {
 
   spec = {
     bucket_name  = "public-cdn-assets"
-    account_id   = "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6"
-    location     = 3  # WEUR
+    account_id   = "0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d"
+    location     = "weur"  # Western Europe
     public_access = true
   }
 }
@@ -281,8 +274,8 @@ module "bucket_us" {
 
   spec = {
     bucket_name = "myapp-assets-us"
-    account_id  = "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6"
-    location    = 2  # ENAM
+    account_id  = "0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d"
+    location    = "enam"  # Eastern North America
   }
 }
 
@@ -296,8 +289,8 @@ module "bucket_eu" {
 
   spec = {
     bucket_name = "myapp-assets-eu"
-    account_id  = "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6"
-    location    = 3  # WEUR
+    account_id  = "0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d"
+    location    = "weur"  # Western Europe
   }
 }
 ```
@@ -357,7 +350,7 @@ terraform apply  # Apply changes
 **Change location**:
 
 ```hcl
-location = 5  # APAC instead of WEUR
+location = "apac"  # Asia-Pacific instead of weur
 ```
 
 **Enable public access**:
@@ -519,21 +512,19 @@ tfsec .
 
 ### Public Access
 
-The Cloudflare Terraform provider does not yet expose a field for toggling the r2.dev public URL. When `public_access: true` is specified:
-- Terraform creates the bucket
-- Public access must be enabled manually via Cloudflare Dashboard or API
+The managed r2.dev public URL has its own lifecycle and is configured outside this module. For production public access, attach a custom domain (`custom_domain`), which this module provisions directly.
 - See: https://developers.cloudflare.com/r2/buckets/public-buckets/
 
 ### Versioning
 
-R2 does not support object versioning. The `versioning_enabled` field is ignored.
+R2 does not support object versioning, so it is not modeled by this component.
 
 ## Additional Resources
 
 - [Cloudflare Terraform Provider Docs](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs)
 - [Cloudflare R2 API Docs](https://developers.cloudflare.com/api/operations/r2-create-bucket)
 - [Component README](../../README.md) - User-facing documentation
-- [Examples](../../examples.md) - Complete usage examples
+- [Presets](../../presets/) - Complete usage examples
 
 ## Support
 

--- a/apis/org/openmcf/provider/cloudflare/cloudflarer2bucket/v1/iac/tf/locals.tf
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarer2bucket/v1/iac/tf/locals.tf
@@ -1,36 +1,31 @@
 locals {
   # Resource naming
   resource_name = coalesce(try(var.metadata.name, null), "cloudflare-r2-bucket")
-  
+
   # Labels/tags
   labels = merge({
     "name" = local.resource_name
   }, try(var.metadata.labels, {}))
 
-  # Location enum to string mapping
-  location_map = {
-    0 = "auto"         # auto (Cloudflare chooses optimal region)
-    1 = "WNAM"         # Western North America
-    2 = "ENAM"         # Eastern North America
-    3 = "WEUR"         # Western Europe
-    4 = "EEUR"         # Eastern Europe
-    5 = "APAC"         # Asia-Pacific
-    6 = "OC"           # Oceania
-  }
-  
-  location = lookup(local.location_map, try(var.spec.location, 0), "auto")
-  
   # Bucket configuration
   bucket_name = var.spec.bucket_name
   account_id  = var.spec.account_id
-  
-  # Public access and versioning flags
-  public_access       = coalesce(try(var.spec.public_access, null), false)
-  versioning_enabled  = coalesce(try(var.spec.versioning_enabled, null), false)
 
-  # Custom domain configuration
+  # Location hint. The enum value already matches Cloudflare's expected string;
+  # "auto" means "no hint", which the provider expresses by omitting the field.
+  location      = coalesce(try(var.spec.location, null), "auto")
+  location_hint = local.location == "auto" ? null : local.location
+
+  # Public access via the managed r2.dev URL is handled outside this module.
+  public_access = coalesce(try(var.spec.public_access, null), false)
+
+  # Path-style S3 API URL for the bucket.
+  bucket_url = "https://${local.account_id}.r2.cloudflarestorage.com/${local.bucket_name}"
+
+  # Custom domain configuration. zone_id is resolved to a plain string before
+  # this module runs, so it is read directly.
   custom_domain_enabled = try(var.spec.custom_domain.enabled, false)
-  custom_domain_zone_id = try(var.spec.custom_domain.zone_id.value, "")
+  custom_domain_zone_id = try(var.spec.custom_domain.zone_id, "")
   custom_domain_name    = try(var.spec.custom_domain.domain, "")
 }
 

--- a/apis/org/openmcf/provider/cloudflare/cloudflarer2bucket/v1/iac/tf/main.tf
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarer2bucket/v1/iac/tf/main.tf
@@ -1,25 +1,22 @@
 # Cloudflare R2 Bucket
-# R2 is Cloudflare's S3-compatible object storage with zero egress fees
+# R2 is Cloudflare's S3-compatible object storage with zero egress fees.
+# The location hint is omitted when "auto" so Cloudflare selects the region.
 resource "cloudflare_r2_bucket" "main" {
   account_id = local.account_id
   name       = local.bucket_name
-  location   = local.location
+  location   = local.location_hint
 }
 
-# Note: Public access (r2.dev subdomain) is not yet supported in the Terraform provider
-# It must be enabled manually via the Cloudflare Dashboard or API
-# See: https://developers.cloudflare.com/r2/buckets/public-buckets/
+# Public access via the managed r2.dev URL is configured outside this module
+# (it has its own lifecycle); custom domains are the production-grade path below.
 
-# Note: R2 does not support object versioning
-# The versioning_enabled field is ignored
-
-# Custom domain for the R2 bucket
-# Created only when custom_domain.enabled is true
+# Custom domain for the R2 bucket. Created only when custom_domain.enabled is true.
 resource "cloudflare_r2_custom_domain" "main" {
   count = local.custom_domain_enabled ? 1 : 0
 
   account_id  = local.account_id
   bucket_name = cloudflare_r2_bucket.main.name
   zone_id     = local.custom_domain_zone_id
-  hostname    = local.custom_domain_name
+  domain      = local.custom_domain_name
+  enabled     = true
 }

--- a/apis/org/openmcf/provider/cloudflare/cloudflarer2bucket/v1/iac/tf/outputs.tf
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarer2bucket/v1/iac/tf/outputs.tf
@@ -3,19 +3,9 @@ output "bucket_name" {
   value       = cloudflare_r2_bucket.main.name
 }
 
-output "bucket_id" {
-  description = "The ID of the R2 bucket"
-  value       = cloudflare_r2_bucket.main.id
-}
-
-output "account_id" {
-  description = "The Cloudflare account ID"
-  value       = cloudflare_r2_bucket.main.account_id
-}
-
-output "location" {
-  description = "The location hint for the R2 bucket"
-  value       = cloudflare_r2_bucket.main.location
+output "bucket_url" {
+  description = "The path-style S3 API URL for the bucket"
+  value       = local.bucket_url
 }
 
 output "custom_domain_url" {

--- a/apis/org/openmcf/provider/cloudflare/cloudflarer2bucket/v1/iac/tf/provider.tf
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarer2bucket/v1/iac/tf/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/apis/org/openmcf/provider/cloudflare/cloudflarer2bucket/v1/iac/tf/variables.tf
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarer2bucket/v1/iac/tf/variables.tf
@@ -20,31 +20,20 @@ variable "spec" {
     # Cloudflare account ID (32 hex characters)
     account_id = string
 
-    # Primary region for the bucket (location hint)
-    # 1=WNAM, 2=ENAM, 3=WEUR, 4=EEUR, 5=APAC, 6=OC
-    location = number
+    # Primary region for the bucket (location hint), e.g. "auto", "wnam",
+    # "enam", "weur", "eeur", "apac", "oc". "auto" lets Cloudflare choose.
+    location = optional(string)
 
-    # Expose bucket via public URL (r2.dev domain)
+    # Expose bucket via the managed r2.dev public URL.
     public_access = optional(bool, false)
-
-    # Enable object versioning (Note: R2 does not support versioning)
-    versioning_enabled = optional(bool, false)
 
     # Custom domain configuration for the bucket
     custom_domain = optional(object({
       # Whether to enable custom domain access for the bucket
       enabled = bool
 
-      # The Cloudflare Zone ID (literal value or reference)
-      zone_id = object({
-        value      = optional(string)
-        value_from = optional(object({
-          kind       = optional(string)
-          env        = optional(string)
-          name       = string
-          field_path = optional(string)
-        }))
-      })
+      # The Cloudflare Zone ID hosting the custom domain (resolved literal).
+      zone_id = optional(string)
 
       # The full domain name to use for accessing the bucket
       domain = string

--- a/apis/org/openmcf/provider/cloudflare/cloudflarer2bucket/v1/presets/01-private.md
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarer2bucket/v1/presets/01-private.md
@@ -11,7 +11,7 @@ Creates a private R2 bucket with no public access. Data is accessible only via W
 ## Key Configuration Choices
 
 - **publicAccess: false** (`publicAccess: false`) -- No public URL; access via Workers or credentials only.
-- **location** (`location: auto`) -- Auto lets Cloudflare choose; or WNAM, ENAM, WEUR, EEUR, APAC, OC.
+- **location** (`location: auto`) -- Auto lets Cloudflare choose; or wnam, enam, weur, eeur, apac, oc.
 - **bucketName** (`bucketName`) -- DNS-compatible, 3–63 chars, lowercase alphanumeric and hyphens.
 
 ## Placeholders to Replace

--- a/apis/org/openmcf/provider/cloudflare/cloudflarer2bucket/v1/spec.pb.go
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarer2bucket/v1/spec.pb.go
@@ -9,6 +9,7 @@ package cloudflarer2bucketv1
 import (
 	_ "buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go/buf/validate"
 	v1 "github.com/plantonhq/openmcf/apis/org/openmcf/shared/foreignkey/v1"
+	_ "github.com/plantonhq/openmcf/apis/org/openmcf/shared/options"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
@@ -23,39 +24,41 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-// Supported Cloudflare R2 bucket regions (location hints).
-// These values must match Cloudflare's expected location strings exactly.
+// Location hint for an R2 bucket's primary storage region. The hint influences
+// where objects are initially placed; R2 still serves and caches globally.
+// Value names match the strings the Cloudflare API expects exactly, so the
+// generated enum is used directly (.String()) when calling the provider.
 type CloudflareR2Location int32
 
 const (
-	CloudflareR2Location_auto CloudflareR2Location = 0 // Auto (Cloudflare chooses optimal region)
-	CloudflareR2Location_WNAM CloudflareR2Location = 1 // Western North America (US West)
-	CloudflareR2Location_ENAM CloudflareR2Location = 2 // Eastern North America (US East)
-	CloudflareR2Location_WEUR CloudflareR2Location = 3 // Western Europe
-	CloudflareR2Location_EEUR CloudflareR2Location = 4 // Eastern Europe
-	CloudflareR2Location_APAC CloudflareR2Location = 5 // Asia-Pacific
-	CloudflareR2Location_OC   CloudflareR2Location = 6 // Oceania
+	CloudflareR2Location_auto CloudflareR2Location = 0 // No location hint; Cloudflare selects the optimal region.
+	CloudflareR2Location_wnam CloudflareR2Location = 1 // Western North America (US West).
+	CloudflareR2Location_enam CloudflareR2Location = 2 // Eastern North America (US East).
+	CloudflareR2Location_weur CloudflareR2Location = 3 // Western Europe.
+	CloudflareR2Location_eeur CloudflareR2Location = 4 // Eastern Europe.
+	CloudflareR2Location_apac CloudflareR2Location = 5 // Asia-Pacific.
+	CloudflareR2Location_oc   CloudflareR2Location = 6 // Oceania.
 )
 
 // Enum value maps for CloudflareR2Location.
 var (
 	CloudflareR2Location_name = map[int32]string{
 		0: "auto",
-		1: "WNAM",
-		2: "ENAM",
-		3: "WEUR",
-		4: "EEUR",
-		5: "APAC",
-		6: "OC",
+		1: "wnam",
+		2: "enam",
+		3: "weur",
+		4: "eeur",
+		5: "apac",
+		6: "oc",
 	}
 	CloudflareR2Location_value = map[string]int32{
 		"auto": 0,
-		"WNAM": 1,
-		"ENAM": 2,
-		"WEUR": 3,
-		"EEUR": 4,
-		"APAC": 5,
-		"OC":   6,
+		"wnam": 1,
+		"enam": 2,
+		"weur": 3,
+		"eeur": 4,
+		"apac": 5,
+		"oc":   6,
 	}
 )
 
@@ -93,7 +96,9 @@ type CloudflareR2BucketSpec struct {
 	BucketName string `protobuf:"bytes,1,opt,name=bucket_name,json=bucketName,proto3" json:"bucket_name,omitempty"`
 	// The Cloudflare account ID in which to create the bucket.
 	AccountId string `protobuf:"bytes,2,opt,name=account_id,json=accountId,proto3" json:"account_id,omitempty"`
-	// primary region for the bucket (location hint)
+	// Primary region for the bucket (location hint). Leave as `auto` to let
+	// Cloudflare choose the optimal region; the hint is only honored when the
+	// bucket is first created and is best-effort, not a guarantee.
 	Location CloudflareR2Location `protobuf:"varint,3,opt,name=location,proto3,enum=org.openmcf.provider.cloudflare.cloudflarer2bucket.v1.CloudflareR2Location" json:"location,omitempty"`
 	// expose bucket via public URL (Cloudflare-managed r2.dev domain; default: false)
 	PublicAccess bool `protobuf:"varint,4,opt,name=public_access,json=publicAccess,proto3" json:"public_access,omitempty"`
@@ -241,13 +246,13 @@ var File_org_openmcf_provider_cloudflare_cloudflarer2bucket_v1_spec_proto protor
 
 const file_org_openmcf_provider_cloudflare_cloudflarer2bucket_v1_spec_proto_rawDesc = "" +
 	"\n" +
-	"@org/openmcf/provider/cloudflare/cloudflarer2bucket/v1/spec.proto\x125org.openmcf.provider.cloudflare.cloudflarer2bucket.v1\x1a\x1bbuf/validate/validate.proto\x1a2org/openmcf/shared/foreignkey/v1/foreign_key.proto\"\xc0\x03\n" +
+	"@org/openmcf/provider/cloudflare/cloudflarer2bucket/v1/spec.proto\x125org.openmcf.provider.cloudflare.cloudflarer2bucket.v1\x1a\x1bbuf/validate/validate.proto\x1a2org/openmcf/shared/foreignkey/v1/foreign_key.proto\x1a(org/openmcf/shared/options/options.proto\"\xc2\x03\n" +
 	"\x16CloudflareR2BucketSpec\x12N\n" +
 	"\vbucket_name\x18\x01 \x01(\tB-\xbaH*\xc8\x01\x01r%\x10\x03\x18?2\x1f^[a-z0-9]([-a-z0-9]*[a-z0-9])?$R\n" +
 	"bucketName\x12=\n" +
 	"\n" +
-	"account_id\x18\x02 \x01(\tB\x1e\xbaH\x1b\xc8\x01\x01r\x162\x11^[0-9a-fA-F]{32}$\x98\x01 R\taccountId\x12o\n" +
-	"\blocation\x18\x03 \x01(\x0e2K.org.openmcf.provider.cloudflare.cloudflarer2bucket.v1.CloudflareR2LocationB\x06\xbaH\x03\xc8\x01\x01R\blocation\x12#\n" +
+	"account_id\x18\x02 \x01(\tB\x1e\xbaH\x1b\xc8\x01\x01r\x162\x11^[0-9a-fA-F]{32}$\x98\x01 R\taccountId\x12q\n" +
+	"\blocation\x18\x03 \x01(\x0e2K.org.openmcf.provider.cloudflare.cloudflarer2bucket.v1.CloudflareR2LocationB\b\x92\xa6\x1d\x04autoR\blocation\x12#\n" +
 	"\rpublic_access\x18\x04 \x01(\bR\fpublicAccess\x12\x80\x01\n" +
 	"\rcustom_domain\x18\x05 \x01(\v2[.org.openmcf.provider.cloudflare.cloudflarer2bucket.v1.CloudflareR2BucketCustomDomainConfigR\fcustomDomain\"\xc7\x03\n" +
 	"$CloudflareR2BucketCustomDomainConfig\x12\x18\n" +
@@ -258,12 +263,12 @@ const file_org_openmcf_provider_cloudflare_cloudflarer2bucket_v1_spec_proto_rawD
 	"\x1dcustom_domain_domain_required\x120domain is required when custom domain is enabled\x1a\"!this.enabled || this.domain != ''*Z\n" +
 	"\x14CloudflareR2Location\x12\b\n" +
 	"\x04auto\x10\x00\x12\b\n" +
-	"\x04WNAM\x10\x01\x12\b\n" +
-	"\x04ENAM\x10\x02\x12\b\n" +
-	"\x04WEUR\x10\x03\x12\b\n" +
-	"\x04EEUR\x10\x04\x12\b\n" +
-	"\x04APAC\x10\x05\x12\x06\n" +
-	"\x02OC\x10\x06B\xaf\x03\n" +
+	"\x04wnam\x10\x01\x12\b\n" +
+	"\x04enam\x10\x02\x12\b\n" +
+	"\x04weur\x10\x03\x12\b\n" +
+	"\x04eeur\x10\x04\x12\b\n" +
+	"\x04apac\x10\x05\x12\x06\n" +
+	"\x02oc\x10\x06B\xaf\x03\n" +
 	"9com.org.openmcf.provider.cloudflare.cloudflarer2bucket.v1B\tSpecProtoP\x01Zlgithub.com/plantonhq/openmcf/apis/org/openmcf/provider/cloudflare/cloudflarer2bucket/v1;cloudflarer2bucketv1\xa2\x02\x05OOPCC\xaa\x025Org.Openmcf.Provider.Cloudflare.Cloudflarer2bucket.V1\xca\x025Org\\Openmcf\\Provider\\Cloudflare\\Cloudflarer2bucket\\V1\xe2\x02AOrg\\Openmcf\\Provider\\Cloudflare\\Cloudflarer2bucket\\V1\\GPBMetadata\xea\x02:Org::Openmcf::Provider::Cloudflare::Cloudflarer2bucket::V1b\x06proto3"
 
 var (

--- a/apis/org/openmcf/provider/cloudflare/cloudflarer2bucket/v1/spec.proto
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarer2bucket/v1/spec.proto
@@ -4,17 +4,20 @@ package org.openmcf.provider.cloudflare.cloudflarer2bucket.v1;
 
 import "buf/validate/validate.proto";
 import "org/openmcf/shared/foreignkey/v1/foreign_key.proto";
+import "org/openmcf/shared/options/options.proto";
 
-// Supported Cloudflare R2 bucket regions (location hints).
-// These values must match Cloudflare's expected location strings exactly.
+// Location hint for an R2 bucket's primary storage region. The hint influences
+// where objects are initially placed; R2 still serves and caches globally.
+// Value names match the strings the Cloudflare API expects exactly, so the
+// generated enum is used directly (.String()) when calling the provider.
 enum CloudflareR2Location {
-  auto = 0; // Auto (Cloudflare chooses optimal region)
-  WNAM = 1; // Western North America (US West)
-  ENAM = 2; // Eastern North America (US East)
-  WEUR = 3; // Western Europe
-  EEUR = 4; // Eastern Europe
-  APAC = 5; // Asia-Pacific
-  OC = 6; // Oceania
+  auto = 0; // No location hint; Cloudflare selects the optimal region.
+  wnam = 1; // Western North America (US West).
+  enam = 2; // Eastern North America (US East).
+  weur = 3; // Western Europe.
+  eeur = 4; // Eastern Europe.
+  apac = 5; // Asia-Pacific.
+  oc = 6; // Oceania.
 }
 
 // CloudflareR2BucketSpec defines the user configuration for a Cloudflare R2 bucket.
@@ -34,8 +37,10 @@ message CloudflareR2BucketSpec {
     (buf.validate.field).string.pattern = "^[0-9a-fA-F]{32}$"
   ];
 
-  // primary region for the bucket (location hint)
-  CloudflareR2Location location = 3 [(buf.validate.field).required = true];
+  // Primary region for the bucket (location hint). Leave as `auto` to let
+  // Cloudflare choose the optimal region; the hint is only honored when the
+  // bucket is first created and is best-effort, not a guarantee.
+  CloudflareR2Location location = 3 [(org.openmcf.shared.options.recommended_default) = "auto"];
 
   // expose bucket via public URL (Cloudflare-managed r2.dev domain; default: false)
   bool public_access = 4;

--- a/apis/org/openmcf/provider/cloudflare/cloudflarer2bucket/v1/spec_test.go
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarer2bucket/v1/spec_test.go
@@ -30,7 +30,41 @@ var _ = ginkgo.Describe("CloudflareR2BucketSpec Custom Validation Tests", func()
 					Spec: &CloudflareR2BucketSpec{
 						BucketName: "test-bucket",
 						AccountId:  "00000000000000000000000000000000",
-						Location:   CloudflareR2Location_WEUR,
+						Location:   CloudflareR2Location_weur,
+					},
+				}
+				err := protovalidate.Validate(input)
+				gomega.Expect(err).To(gomega.BeNil())
+			})
+
+			ginkgo.It("should not return a validation error when location is omitted (auto)", func() {
+				input := &CloudflareR2Bucket{
+					ApiVersion: "cloudflare.openmcf.org/v1",
+					Kind:       "CloudflareR2Bucket",
+					Metadata: &shared.CloudResourceMetadata{
+						Name: "test-r2-bucket-auto",
+					},
+					Spec: &CloudflareR2BucketSpec{
+						BucketName: "test-auto-bucket",
+						AccountId:  "00000000000000000000000000000000",
+						// Location left unset == auto (no hint).
+					},
+				}
+				err := protovalidate.Validate(input)
+				gomega.Expect(err).To(gomega.BeNil())
+			})
+
+			ginkgo.It("should not return a validation error for a non-auto region", func() {
+				input := &CloudflareR2Bucket{
+					ApiVersion: "cloudflare.openmcf.org/v1",
+					Kind:       "CloudflareR2Bucket",
+					Metadata: &shared.CloudResourceMetadata{
+						Name: "test-r2-bucket-region",
+					},
+					Spec: &CloudflareR2BucketSpec{
+						BucketName: "test-region-bucket",
+						AccountId:  "00000000000000000000000000000000",
+						Location:   CloudflareR2Location_enam,
 					},
 				}
 				err := protovalidate.Validate(input)
@@ -47,7 +81,7 @@ var _ = ginkgo.Describe("CloudflareR2BucketSpec Custom Validation Tests", func()
 					Spec: &CloudflareR2BucketSpec{
 						BucketName:   "test-public-bucket",
 						AccountId:    "00000000000000000000000000000000",
-						Location:     CloudflareR2Location_WEUR,
+						Location:     CloudflareR2Location_weur,
 						PublicAccess: true,
 					},
 				}
@@ -65,7 +99,7 @@ var _ = ginkgo.Describe("CloudflareR2BucketSpec Custom Validation Tests", func()
 					Spec: &CloudflareR2BucketSpec{
 						BucketName: "test-custom-domain-bucket",
 						AccountId:  "00000000000000000000000000000000",
-						Location:   CloudflareR2Location_WEUR,
+						Location:   CloudflareR2Location_weur,
 						CustomDomain: &CloudflareR2BucketCustomDomainConfig{
 							Enabled: true,
 							ZoneId: &foreignkeyv1.StringValueOrRef{
@@ -91,7 +125,7 @@ var _ = ginkgo.Describe("CloudflareR2BucketSpec Custom Validation Tests", func()
 					Spec: &CloudflareR2BucketSpec{
 						BucketName: "test-disabled-custom-domain",
 						AccountId:  "00000000000000000000000000000000",
-						Location:   CloudflareR2Location_WEUR,
+						Location:   CloudflareR2Location_weur,
 						CustomDomain: &CloudflareR2BucketCustomDomainConfig{
 							Enabled: false,
 						},
@@ -115,7 +149,7 @@ var _ = ginkgo.Describe("CloudflareR2BucketSpec Custom Validation Tests", func()
 					},
 					Spec: &CloudflareR2BucketSpec{
 						BucketName: "test-bucket",
-						Location:   CloudflareR2Location_WEUR,
+						Location:   CloudflareR2Location_weur,
 					},
 				}
 				err := protovalidate.Validate(input)
@@ -132,7 +166,7 @@ var _ = ginkgo.Describe("CloudflareR2BucketSpec Custom Validation Tests", func()
 					Spec: &CloudflareR2BucketSpec{
 						BucketName: "test-bucket",
 						AccountId:  "123",
-						Location:   CloudflareR2Location_WEUR,
+						Location:   CloudflareR2Location_weur,
 					},
 				}
 				err := protovalidate.Validate(input)
@@ -149,7 +183,7 @@ var _ = ginkgo.Describe("CloudflareR2BucketSpec Custom Validation Tests", func()
 					Spec: &CloudflareR2BucketSpec{
 						BucketName: "test-bucket",
 						AccountId:  "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ",
-						Location:   CloudflareR2Location_WEUR,
+						Location:   CloudflareR2Location_weur,
 					},
 				}
 				err := protovalidate.Validate(input)
@@ -168,7 +202,7 @@ var _ = ginkgo.Describe("CloudflareR2BucketSpec Custom Validation Tests", func()
 					},
 					Spec: &CloudflareR2BucketSpec{
 						AccountId: "00000000000000000000000000000000",
-						Location:  CloudflareR2Location_WEUR,
+						Location:  CloudflareR2Location_weur,
 					},
 				}
 				err := protovalidate.Validate(input)
@@ -185,7 +219,7 @@ var _ = ginkgo.Describe("CloudflareR2BucketSpec Custom Validation Tests", func()
 					Spec: &CloudflareR2BucketSpec{
 						BucketName: "ab",
 						AccountId:  "00000000000000000000000000000000",
-						Location:   CloudflareR2Location_WEUR,
+						Location:   CloudflareR2Location_weur,
 					},
 				}
 				err := protovalidate.Validate(input)
@@ -202,7 +236,7 @@ var _ = ginkgo.Describe("CloudflareR2BucketSpec Custom Validation Tests", func()
 					Spec: &CloudflareR2BucketSpec{
 						BucketName: "Test_Bucket",
 						AccountId:  "00000000000000000000000000000000",
-						Location:   CloudflareR2Location_WEUR,
+						Location:   CloudflareR2Location_weur,
 					},
 				}
 				err := protovalidate.Validate(input)
@@ -222,7 +256,7 @@ var _ = ginkgo.Describe("CloudflareR2BucketSpec Custom Validation Tests", func()
 					Spec: &CloudflareR2BucketSpec{
 						BucketName: "test-bucket",
 						AccountId:  "00000000000000000000000000000000",
-						Location:   CloudflareR2Location_WEUR,
+						Location:   CloudflareR2Location_weur,
 						CustomDomain: &CloudflareR2BucketCustomDomainConfig{
 							Enabled: true,
 							Domain:  "media.example.com",
@@ -243,7 +277,7 @@ var _ = ginkgo.Describe("CloudflareR2BucketSpec Custom Validation Tests", func()
 					Spec: &CloudflareR2BucketSpec{
 						BucketName: "test-bucket",
 						AccountId:  "00000000000000000000000000000000",
-						Location:   CloudflareR2Location_WEUR,
+						Location:   CloudflareR2Location_weur,
 						CustomDomain: &CloudflareR2BucketCustomDomainConfig{
 							Enabled: true,
 							ZoneId: &foreignkeyv1.StringValueOrRef{
@@ -268,7 +302,7 @@ var _ = ginkgo.Describe("CloudflareR2BucketSpec Custom Validation Tests", func()
 					Spec: &CloudflareR2BucketSpec{
 						BucketName: "test-bucket",
 						AccountId:  "00000000000000000000000000000000",
-						Location:   CloudflareR2Location_WEUR,
+						Location:   CloudflareR2Location_weur,
 						CustomDomain: &CloudflareR2BucketCustomDomainConfig{
 							Enabled: true,
 							ZoneId: &foreignkeyv1.StringValueOrRef{

--- a/pkg/iac/MODULE_PARITY.md
+++ b/pkg/iac/MODULE_PARITY.md
@@ -108,3 +108,15 @@ not flag the `_id` suffix), so it needs no annotation. The cluster-wide
 `KubernetesZalandoPostgresOperator` backup config mirrors the same `bucket` + `object_prefix` +
 `credentials` shape, composing the identical `WALG_S3_PREFIX` into its operator configmap on both
 engines. None of these are stack outputs, so the conformance guard is unaffected.
+
+The `CloudflareR2Bucket` module pins the Cloudflare provider to v5 on both engines (tofu
+`~> 5.0`, Pulumi `sdk/v6`). The `location` hint is the enum value used verbatim as the provider
+string (`wnam`/`enam`/`weur`/`eeur`/`apac`/`oc`); `auto` (the enum zero value) means "no hint" and
+is omitted from the resource on both sides (tofu sets the attribute to `null`, Pulumi leaves the
+`Location` arg unset), letting Cloudflare choose. The custom domain (`cloudflare_r2_custom_domain`)
+is created only when `custom_domain.enabled` and uses the v5 attributes `domain` + `enabled = true`
+on both engines; `custom_domain.zone_id` is a `StringValueOrRef` resolved to a plain string before
+tfvars, so `variables.tf` types it as `optional(string)`. Stack outputs are the three proto fields
+`bucket_name`, `bucket_url` (the path-style `https://<account_id>.r2.cloudflarestorage.com/<bucket>`
+S3 URL), and `custom_domain_url` (set only when a custom domain is enabled) — see the conformance
+guard's `CloudflareR2Bucket` case.

--- a/pkg/outputs/conformance_test.go
+++ b/pkg/outputs/conformance_test.go
@@ -171,6 +171,19 @@ func TestStackOutputsConformance(t *testing.T) {
 			},
 			mustPopulate: []string{"namespace", "release_name", "solver_sa"},
 		},
+		{
+			// CloudflareR2Bucket: both engines emit the same three flat outputs
+			// (bucket name, path-style S3 URL, custom domain URL), each of which
+			// must land on the StackOutputs proto.
+			name: "CloudflareR2Bucket",
+			kind: cloudresourcekind.CloudResourceKind_CloudflareR2Bucket,
+			rawOutputs: map[string]interface{}{
+				"bucket_name":       "media-assets",
+				"bucket_url":        "https://00000000000000000000000000000000.r2.cloudflarestorage.com/media-assets",
+				"custom_domain_url": "https://media.example.com",
+			},
+			mustPopulate: []string{"bucket_name", "bucket_url", "custom_domain_url"},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary

Makes `CloudflareR2Bucket` deploy cleanly on Cloudflare provider **v5** across both IaC engines, with tofu<->pulumi parity and stack outputs matching the proto contract. The OpenTofu module pinned `~> 4.0` while declaring the v5-only `cloudflare_r2_custom_domain`, so every tofu deploy failed schema validation with `Invalid resource type`.

## What changed

- **Provider pin**: OpenTofu module -> `~> 5.0` (matches the Pulumi module, already on `sdk/v6`).
- **Custom domain**: v5 attributes `domain` + `enabled` on both engines.
- **Location**: enum values match the provider strings (`auto`/`wnam`/`enam`/`weur`/`eeur`/`apac`/`oc`), used via `.String()`; `auto` means "no hint" and is omitted on both engines so Cloudflare chooses; `location` is optional with recommended default `auto`. Fixes three latent bugs: enum-as-number typing, `required` rejecting the `auto` default, and uppercase regions not matching v5.
- **Tofu variables**: `location` and `custom_domain.zone_id` typed `optional(string)` to match how manifests render into tfvars (enums as strings; `StringValueOrRef` flattened to a string).
- **Stack outputs**: both engines emit `bucket_name`, `bucket_url` (`https://<account_id>.r2.cloudflarestorage.com/<bucket>`), and `custom_domain_url`; unmapped tofu outputs trimmed to satisfy the conformance guard.
- Docs/presets/MODULE_PARITY refreshed to the v5 design; new `_changelog` entry.

## Breaking change

`!` marks the `CloudflareR2Location` enum value rename (uppercase regions -> lowercase) and the reconciled stack outputs.

## Test plan

- [x] `make protos`, `go build`/`go vet`, component spec tests (incl. new auto/region cases)
- [x] `pkg/outputs` conformance (new `CloudflareR2Bucket` case) + `pkg/secretcoverage`; `openmcf secret-coverage --check`
- [x] `openmcf tofu load-tfvars` confirms `location`/`zone_id` render as strings
- [x] `tofu init`/`validate`/`plan` clean on provider v5.21.1, with and without `custom_domain`
- [x] Real `apply`+`destroy`: plain bucket and bucket+custom_domain on a live zone; all outputs populated; cleaned up