### PR TITLE
fix(cloudflare)!: migrate the remaining eight Cloudflare components to provider v5

### DIFF
--- a/_changelog/2026-06/2026-06-24-230148-cloudflare-provider-v5-remaining-eight-components.md
+++ b/_changelog/2026-06/2026-06-24-230148-cloudflare-provider-v5-remaining-eight-components.md
@@ -1,0 +1,129 @@
+# Cloudflare provider v5 migration — the remaining eight components
+
+**Date**: June 24, 2026
+**Type**: Breaking Change
+**Components**: API Definitions, Provider Framework, IAC Stack Runner, Pulumi CLI Integration, Manifest Processing
+
+## Summary
+
+Completes the migration of the entire Cloudflare provider family to Terraform provider **v5**
+(`cloudflare ~> 5.0`) / Pulumi `sdk/v6`. With `CloudflareR2Bucket` already shipped, this change
+brings the other eight kinds — D1, KV namespace, DNS record, DNS zone, ruleset, load balancer,
+worker, and zero-trust access application — onto v5 with full Terraform↔Pulumi parity and outputs
+that match each `*_stack_outputs.proto`. Every Cloudflare kind now plans and deploys on provider v5.
+
+## Problem Statement / Motivation
+
+The Cloudflare provider v5 is a generated rewrite of v4: resources were renamed, enum casing
+changed, and many nested **blocks** became nested **attributes**. All nine OpenMCF Cloudflare
+modules were pinned to `~> 4.0` and used v4 syntax, so none could `plan` against v5. Beyond the
+version pin, the audit surfaced real latent defects that would break deploys on any version.
+
+### Pain Points
+
+- **Every module pinned `cloudflare ~> 4.0`** and used removed/renamed resources and block syntax.
+- **`StringValueOrRef` mistyped as `object({ value })`** in Terraform `variables.tf`. The tfvars
+  converter flattens `StringValueOrRef` to a bare string, so these modules failed on real manifests
+  (present in dns_record, ruleset, load_balancer, worker, zero_trust).
+- **Enums typed as numbers.** The converter emits enum *names* (e.g. `cookie`, `random`), but the
+  load balancer and worker modules treated `session_affinity`/`steering_policy`/`usage_model` as
+  numeric lookups — always falling back to the default.
+- **Cross-engine drift.** Several Pulumi modules lagged (deprecated `NewRecord`, an orphaned
+  zero-trust policy, a load balancer missing the required `account_id`, a worker dropping secrets).
+- **KV could not deploy at all on v5** — see Breaking Changes.
+
+## Solution / What's New
+
+Each component was migrated through the `update-openmcf-component` flow: read the component's own
+docs, then the v5 `schema.go`; migrate Terraform and Pulumi together; reconcile parity; validate;
+refresh public artifacts.
+
+```mermaid
+flowchart LR
+    A[v4 module: ~> 4.0, blocks, object zone_id] --> B[Read v5 schema.go]
+    B --> C[Terraform: ~> 5.0, attribute syntax, optional string]
+    B --> D[Pulumi: sdk/v6 args, fix parity defects]
+    C --> E[tofu validate + real tofu plan]
+    D --> F[go build + go test]
+    E --> G[conformance case per kind]
+    F --> G
+    G --> H[v5-correct, parity-locked component]
+```
+
+### Per-component highlights
+
+- **D1**: `read_replication` v4 dynamic block → v5 single-nested attribute.
+- **KV namespace**: built out the previously-stub Terraform module; **added required `account_id`**
+  (see Breaking Changes).
+- **DNS record**: `cloudflare_record` → `cloudflare_dns_record`; `.hostname` output → `.name`.
+- **DNS zone**: nested `account = { id }`; removed v5-deleted `plan`/`jump_start` and the
+  `cloudflare_zone_settings_override` resource; embedded records → `cloudflare_dns_record`.
+- **Ruleset**: every `dynamic` block → v5 attribute syntax; header transforms became a map keyed
+  by header name.
+- **Load balancer**: `default_pools`/`fallback_pool`; the account-scoped pool and monitor now derive
+  `account_id` from a `cloudflare_zone` data source (Pulumi `LookupZone`) — no spec change needed.
+- **Worker**: per-type binding blocks → the flat v5 `bindings` list; `workers_route`; `main_module`.
+- **Zero-trust access application**: v5 model where a standalone account-scoped policy is referenced
+  by the application's `policies` list; include/require rules became single-nested objects.
+
+## Implementation Details
+
+- **Terraform**: provider pinned to `~> 5.0`; all v4 `dynamic` blocks rewritten to attribute
+  (object/list/map) syntax; `StringValueOrRef` variables retyped to `optional(string)` with the
+  `.value`/`.ref` dereferences removed; enum fields retyped to strings consumed directly.
+- **Pulumi**: confirmed `sdk/v6` usage and fixed lagging calls — `NewDnsRecord` (dns zone + worker),
+  `AccountId` on load balancer pool/monitor via `LookupZone`, `secret_text` worker bindings,
+  and the zero-trust policy now created first and attached through the application's `policies` list
+  with both resources scoped by `account_id`.
+- **Outputs/parity**: each module reconciled to its `*_stack_outputs.proto`, and a per-kind case was
+  added to `pkg/outputs/conformance_test.go` so Terraform↔Pulumi output parity is enforced in CI.
+
+## Breaking Changes
+
+- **`CloudflareKvNamespaceSpec` gains a required `account_id`** (field 4). Cloudflare provider v5
+  makes `account_id` required on `cloudflare_workers_kv_namespace`, and a KV namespace is
+  account-scoped with no zone to derive it from, so the field is unavoidable. It mirrors the existing
+  `account_id` on `CloudflareR2Bucket` and `CloudflareD1Database` (plain required 32-hex string).
+- **Provider major bump to v5 across all Cloudflare kinds.** Existing state created with the v4
+  provider must be migrated per Cloudflare's v5 upgrade guidance.
+
+## Validation / Testing Strategy
+
+Agent-owned and green before handoff:
+
+```bash
+make -C apis protos                                   # KV proto regen
+go test ./apis/org/openmcf/provider/cloudflare/...    # all nine components
+go test ./pkg/outputs/                                # conformance (all nine kinds)
+openmcf secret-coverage --check
+# per component:
+tofu init && tofu validate                            # offline, against real v5 provider
+tofu plan -var-file=<generated tfvars>                # real, read-only, live account
+```
+
+A real `tofu plan` against a live Cloudflare account confirmed D1, KV, DNS record, DNS zone,
+ruleset, load balancer, and zero-trust (the load balancer and zero-trust data-source reads exercise
+the live zone → account derivation). The worker module's R2 bundle data source needs a real object,
+so its v5 `bindings` were type-checked against the live provider in isolation.
+
+## Benefits
+
+- Every Cloudflare kind plans and deploys on provider v5; the family is unblocked for downstream use.
+- Real latent defects (the `object({ value })` mistyping, enum-as-number, cross-engine drift) are
+  fixed, not just version-bumped.
+- Terraform↔Pulumi output parity is now CI-enforced for all nine kinds.
+
+## Impact
+
+CLI users deploying any Cloudflare resource now run on the current provider. Anyone with existing
+v4-provider state must follow the v5 upgrade path; KV manifests must add `accountId`.
+
+## Related Work
+
+- `_changelog/2026-06/2026-06-24-203431-cloudflare-r2-bucket-provider-v5.md` — the R2 migration that
+  established the pattern this change follows.
+
+---
+
+**Status**: ✅ Production Ready
+**Timeline**: Single session; eight components, one commit each.

--- a/apis/org/openmcf/provider/cloudflare/cloudflared1database/v1/docs/README.md
+++ b/apis/org/openmcf/provider/cloudflare/cloudflared1database/v1/docs/README.md
@@ -121,7 +121,7 @@ resource "cloudflare_workers_script" "app" {
 
 ```go
 import (
-    "github.com/pulumi/pulumi-cloudflare/sdk/v5/go/cloudflare"
+    "github.com/pulumi/pulumi-cloudflare/sdk/v6/go/cloudflare"
     "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/apis/org/openmcf/provider/cloudflare/cloudflared1database/v1/hack/manifest.yaml
+++ b/apis/org/openmcf/provider/cloudflare/cloudflared1database/v1/hack/manifest.yaml
@@ -1,5 +1,10 @@
 apiVersion: cloudflare.openmcf.org/v1
 kind: CloudflareD1Database
 metadata:
-  name: first-certificate
+  name: d1-hack-database
 spec:
+  databaseName: openmcf-d1-hack
+  accountId: 0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d
+  region: wnam
+  readReplication:
+    mode: disabled

--- a/apis/org/openmcf/provider/cloudflare/cloudflared1database/v1/iac/tf/README.md
+++ b/apis/org/openmcf/provider/cloudflare/cloudflared1database/v1/iac/tf/README.md
@@ -229,7 +229,7 @@ terraform {
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/apis/org/openmcf/provider/cloudflare/cloudflared1database/v1/iac/tf/main.tf
+++ b/apis/org/openmcf/provider/cloudflare/cloudflared1database/v1/iac/tf/main.tf
@@ -8,12 +8,9 @@ resource "cloudflare_d1_database" "main" {
   # Add optional primary location hint (region) if specified
   primary_location_hint = var.spec.region
 
-  # Add optional read replication configuration if specified
-  dynamic "read_replication" {
-    for_each = var.spec.read_replication != null ? [var.spec.read_replication] : []
-    content {
-      mode = read_replication.value.mode
-    }
-  }
+  # Read replication is a single nested attribute; set it only when configured.
+  read_replication = var.spec.read_replication != null ? {
+    mode = var.spec.read_replication.mode
+  } : null
 }
 

--- a/apis/org/openmcf/provider/cloudflare/cloudflared1database/v1/iac/tf/provider.tf
+++ b/apis/org/openmcf/provider/cloudflare/cloudflared1database/v1/iac/tf/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/apis/org/openmcf/provider/cloudflare/cloudflarednsrecord/v1/docs/README.md
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarednsrecord/v1/docs/README.md
@@ -134,7 +134,7 @@ terraform {
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }
@@ -144,31 +144,33 @@ provider "cloudflare" {
 }
 
 # A Record
-resource "cloudflare_record" "www" {
+resource "cloudflare_dns_record" "www" {
   zone_id = var.zone_id
   name    = "www"
   type    = "A"
-  value   = "192.0.2.1"
+  content = "192.0.2.1"
   proxied = true
   ttl     = 1
   comment = "Primary web server"
 }
 
 # CNAME Record
-resource "cloudflare_record" "api" {
+resource "cloudflare_dns_record" "api" {
   zone_id = var.zone_id
   name    = "api"
   type    = "CNAME"
-  value   = "api-lb.example.com"
+  content = "api-lb.example.com"
   proxied = true
+  ttl     = 1
 }
 
 # MX Record (note: cannot be proxied)
-resource "cloudflare_record" "mx_primary" {
+resource "cloudflare_dns_record" "mx_primary" {
   zone_id  = var.zone_id
   name     = "@"
   type     = "MX"
-  value    = "mail.example.com"
+  content  = "mail.example.com"
+  ttl      = 1
   priority = 10
 }
 ```
@@ -404,7 +406,7 @@ iac/tf/
 **Key implementation details:**
 1. Variables mirror the protobuf spec exactly
 2. Locals handle type conversion and defaults
-3. Single `cloudflare_record` resource
+3. Single `cloudflare_dns_record` resource
 4. Outputs match `stack_outputs.proto`
 
 ## Production Best Practices

--- a/apis/org/openmcf/provider/cloudflare/cloudflarednsrecord/v1/iac/hack/manifest.yaml
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarednsrecord/v1/iac/hack/manifest.yaml
@@ -3,7 +3,8 @@ kind: CloudflareDnsRecord
 metadata:
   name: test-dns-record
 spec:
-  zone_id: "test-zone-id-abc123"
+  zone_id:
+    value: "0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d"
   name: "www"
   type: A
   value: "192.0.2.1"

--- a/apis/org/openmcf/provider/cloudflare/cloudflarednsrecord/v1/iac/tf/main.tf
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarednsrecord/v1/iac/tf/main.tf
@@ -1,8 +1,8 @@
 # main.tf
 
 # Create the Cloudflare DNS Record
-resource "cloudflare_record" "main" {
-  zone_id = var.spec.zone_id.value
+resource "cloudflare_dns_record" "main" {
+  zone_id = var.spec.zone_id
   name    = var.spec.name
   type    = local.record_type
   content = var.spec.value

--- a/apis/org/openmcf/provider/cloudflare/cloudflarednsrecord/v1/iac/tf/outputs.tf
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarednsrecord/v1/iac/tf/outputs.tf
@@ -2,20 +2,20 @@
 
 output "record_id" {
   description = "The unique identifier of the created DNS record"
-  value       = cloudflare_record.main.id
+  value       = cloudflare_dns_record.main.id
 }
 
 output "hostname" {
-  description = "The fully qualified hostname of the DNS record"
-  value       = cloudflare_record.main.hostname
+  description = "The name of the DNS record"
+  value       = cloudflare_dns_record.main.name
 }
 
 output "record_type" {
   description = "The DNS record type that was created"
-  value       = cloudflare_record.main.type
+  value       = cloudflare_dns_record.main.type
 }
 
 output "proxied" {
   description = "Whether the record is proxied through Cloudflare"
-  value       = cloudflare_record.main.proxied
+  value       = cloudflare_dns_record.main.proxied
 }

--- a/apis/org/openmcf/provider/cloudflare/cloudflarednsrecord/v1/iac/tf/provider.tf
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarednsrecord/v1/iac/tf/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/apis/org/openmcf/provider/cloudflare/cloudflarednsrecord/v1/iac/tf/variables.tf
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarednsrecord/v1/iac/tf/variables.tf
@@ -14,11 +14,9 @@ variable "metadata" {
 variable "spec" {
   description = "CloudflareDnsRecordSpec defines the configuration for creating a DNS record"
   type = object({
-    # (Required) The Cloudflare Zone ID where this DNS record will be created
-    # Supports StringValueOrRef pattern - use {value: "zone-id"} for literal values.
-    zone_id = object({
-      value = string
-    })
+    # (Required) The Cloudflare Zone ID where this DNS record will be created.
+    # StringValueOrRef is flattened to a plain string by the tfvars converter.
+    zone_id = optional(string)
 
     # (Required) The name of the DNS record (e.g., "www", "api", "@" for root)
     name = string

--- a/apis/org/openmcf/provider/cloudflare/cloudflarednszone/v1/README.md
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarednszone/v1/README.md
@@ -248,7 +248,7 @@ After zone creation, you can configure additional settings:
 - **Caching Rules**: Configure cache behavior
 - **WAF Rules**: Set up Web Application Firewall
 
-These settings are managed separately via Cloudflare dashboard, Terraform `cloudflare_zone_settings_override`, or Pulumi.
+These settings are managed separately via Cloudflare dashboard, the per-setting Terraform `cloudflare_zone_setting` resource, or Pulumi.
 
 ## Troubleshooting
 

--- a/apis/org/openmcf/provider/cloudflare/cloudflarednszone/v1/catalog-page.md
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarednszone/v1/catalog-page.md
@@ -7,7 +7,7 @@ Deploys a Cloudflare DNS zone with optional inline DNS record management. The co
 When you deploy a CloudflareDnsZone resource, OpenMCF provisions:
 
 - **DNS Zone** — a `cloudflare_zone` resource attached to the specified Cloudflare account, with configurable pause state
-- **DNS Records** — one `cloudflare_record` resource per entry in the `records` list, created within the zone with support for proxied mode, custom TTL, priority, and comments
+- **DNS Records** — one `cloudflare_dns_record` resource per entry in the `records` list, created within the zone with support for proxied mode, custom TTL, priority, and comments
 
 ## Prerequisites
 

--- a/apis/org/openmcf/provider/cloudflare/cloudflarednszone/v1/docs/README.md
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarednszone/v1/docs/README.md
@@ -45,7 +45,7 @@ Managing DNS zones on Cloudflare can be approached in many ways, from point-and-
 curl -X POST "https://api.cloudflare.com/client/v4/zones" \
   -H "Authorization: Bearer $CF_API_TOKEN" \
   -H "Content-Type: application/json" \
-  --data '{"name":"example.com","account":{"id":"'$ACCOUNT_ID'"},"jump_start":false}'
+  --data '{"name":"example.com","account":{"id":"'$ACCOUNT_ID'"}}'
 
 # Add an A record
 curl -X POST "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/dns_records" \
@@ -128,28 +128,27 @@ provider "cloudflare" {
 }
 
 resource "cloudflare_zone" "example" {
-  zone       = "example.com"
-  account_id = var.cloudflare_account_id
-  plan       = "free"
-  paused     = false
+  name = "example.com"
+  account = {
+    id = var.cloudflare_account_id
+  }
+  paused = false
 }
 
-resource "cloudflare_record" "www" {
+resource "cloudflare_dns_record" "www" {
   zone_id = cloudflare_zone.example.id
   name    = "www"
   type    = "A"
-  value   = "198.51.100.4"
+  content = "198.51.100.4"
+  ttl     = 1
   proxied = true
 }
 
-resource "cloudflare_zone_settings_override" "example_settings" {
-  zone_id = cloudflare_zone.example.id
-
-  settings {
-    ssl                      = "full"
-    always_use_https         = "on"
-    automatic_https_rewrites = "on"
-  }
+# In provider v5 each zone setting is its own resource.
+resource "cloudflare_zone_setting" "ssl" {
+  zone_id    = cloudflare_zone.example.id
+  setting_id = "ssl"
+  value      = "full"
 }
 ```
 
@@ -171,7 +170,7 @@ resource "cloudflare_zone_settings_override" "example_settings" {
 cf-terraforming generate --resource-type cloudflare_zone --account $ACCOUNT_ID > zones.tf
 
 # Generate DNS records for a specific zone
-cf-terraforming generate --resource-type cloudflare_record --zone $ZONE_ID > records.tf
+cf-terraforming generate --resource-type cloudflare_dns_record --zone $ZONE_ID > records.tf
 
 # Import state
 terraform import cloudflare_zone.example $ZONE_ID
@@ -397,19 +396,21 @@ Both Terraform and Pulumi are production-ready for managing Cloudflare DNS. Here
 ```hcl
 # Simple and readable for standard use cases
 resource "cloudflare_zone" "example" {
-  zone       = "example.com"
-  account_id = var.account_id
-  plan       = "free"
+  name = "example.com"
+  account = {
+    id = var.account_id
+  }
 }
 
 # Looping requires for_each or count
-resource "cloudflare_record" "subdomains" {
+resource "cloudflare_dns_record" "subdomains" {
   for_each = toset(["app1", "app2", "app3"])
-  
+
   zone_id = cloudflare_zone.example.id
   name    = each.value
   type    = "CNAME"
-  value   = "lb.example.com"
+  content = "lb.example.com"
+  ttl     = 1
   proxied = true
 }
 ```
@@ -699,7 +700,7 @@ Typically enabled post-creation via separate API call or dashboard toggle (not p
 Business/Enterprise feature for branding (e.g., `ns1.yourdomain.com` instead of Cloudflare's NS). Rare need.
 
 **Zone settings (SSL mode, caching rules, WAF):**  
-Managed separately via `cloudflare_zone_settings_override` resource in Terraform or dedicated API calls. Not part of the zone creation spec—these are post-creation configurations.
+Managed separately via the per-setting `cloudflare_zone_setting` resource in Terraform or dedicated API calls. Not part of the zone creation spec—these are post-creation configurations.
 
 ---
 

--- a/apis/org/openmcf/provider/cloudflare/cloudflarednszone/v1/hack/manifest.yaml
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarednszone/v1/hack/manifest.yaml
@@ -1,5 +1,19 @@
 apiVersion: cloudflare.openmcf.org/v1
 kind: CloudflareDnsZone
 metadata:
-  name: first-certificate
+  name: dns-zone-hack
 spec:
+  zoneName: openmcf-example.com
+  accountId: 0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d
+  paused: false
+  records:
+    - name: www
+      type: A
+      value: "192.0.2.1"
+      proxied: true
+      ttl: 1
+    - name: "@"
+      type: MX
+      value: mail.openmcf-example.com
+      ttl: 1
+      priority: 10

--- a/apis/org/openmcf/provider/cloudflare/cloudflarednszone/v1/iac/pulumi/module/records.go
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarednszone/v1/iac/pulumi/module/records.go
@@ -20,7 +20,7 @@ func records(
 		// Include index to ensure uniqueness when multiple records have same name and type
 		resourceName := fmt.Sprintf("%s-%s-%d", record.Name, record.Type.String(), idx)
 
-		recordArgs := &cloudflare.RecordArgs{
+		recordArgs := &cloudflare.DnsRecordArgs{
 			ZoneId:  zone.ID(),
 			Name:    pulumi.String(record.Name),
 			Type:    pulumi.String(record.Type.String()),
@@ -46,7 +46,7 @@ func records(
 			recordArgs.Comment = pulumi.String(record.Comment)
 		}
 
-		_, err := cloudflare.NewRecord(
+		_, err := cloudflare.NewDnsRecord(
 			ctx,
 			resourceName,
 			recordArgs,

--- a/apis/org/openmcf/provider/cloudflare/cloudflarednszone/v1/iac/tf/locals.tf
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarednszone/v1/iac/tf/locals.tf
@@ -28,16 +28,5 @@ locals {
 
   # Merge base, org, and environment labels
   final_labels = merge(local.base_labels, local.org_label, local.env_label)
-
-  # Map plan enum string to Cloudflare plan ID
-  plan_map = {
-    "free"       = "free"
-    "pro"        = "pro"
-    "business"   = "business"
-    "enterprise" = "enterprise"
-  }
-
-  # Get the plan ID, defaulting to free if invalid
-  plan_id = lookup(local.plan_map, lower(var.spec.plan), "free")
 }
 

--- a/apis/org/openmcf/provider/cloudflare/cloudflarednszone/v1/iac/tf/main.tf
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarednszone/v1/iac/tf/main.tf
@@ -2,31 +2,13 @@
 
 # Create the Cloudflare DNS Zone
 resource "cloudflare_zone" "main" {
-  account_id = var.spec.account_id
-  zone       = var.spec.zone_name
-  plan       = local.plan_id
-  paused     = var.spec.paused
-
-  # Jump start automatically scans and imports existing DNS records
-  # Set to false for clean zone creation
-  jump_start = false
+  account = {
+    id = var.spec.account_id
+  }
+  name   = var.spec.zone_name
+  paused = var.spec.paused
 
   # Type is always "full" (standard nameserver delegation)
   # "partial" (CNAME setup) is Business/Enterprise only and not in the 80/20
   type = "full"
-}
-
-# Configure zone settings including default_proxied
-resource "cloudflare_zone_settings_override" "main" {
-  zone_id = cloudflare_zone.main.id
-
-  settings {
-    # Set default proxied behavior for new DNS records
-    # This is configured as a zone setting, not at zone creation
-    always_online = "on"
-    
-    # Note: default_proxied is not a direct zone setting in the Cloudflare API
-    # It's a UI/dashboard feature. For Infrastructure-as-Code, you control
-    # the proxied state explicitly when creating each DNS record.
-  }
 }

--- a/apis/org/openmcf/provider/cloudflare/cloudflarednszone/v1/iac/tf/outputs.tf
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarednszone/v1/iac/tf/outputs.tf
@@ -9,14 +9,3 @@ output "nameservers" {
   description = "The Cloudflare nameservers assigned to this zone"
   value       = cloudflare_zone.main.name_servers
 }
-
-output "zone_name" {
-  description = "The zone name (same as input)"
-  value       = cloudflare_zone.main.zone
-}
-
-output "status" {
-  description = "The current status of the zone"
-  value       = cloudflare_zone.main.status
-}
-

--- a/apis/org/openmcf/provider/cloudflare/cloudflarednszone/v1/iac/tf/provider.tf
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarednszone/v1/iac/tf/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/apis/org/openmcf/provider/cloudflare/cloudflarednszone/v1/iac/tf/records.tf
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarednszone/v1/iac/tf/records.tf
@@ -2,7 +2,7 @@
 
 # Create DNS records within the zone
 # Include index to ensure uniqueness when multiple records have same name and type
-resource "cloudflare_record" "records" {
+resource "cloudflare_dns_record" "records" {
   for_each = { for idx, record in var.spec.records : "${record.name}-${record.type}-${idx}" => record }
 
   zone_id = cloudflare_zone.main.id

--- a/apis/org/openmcf/provider/cloudflare/cloudflarekvnamespace/v1/README.md
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarekvnamespace/v1/README.md
@@ -35,6 +35,7 @@ The specification follows the **80/20 principle**—exposing only the most commo
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `namespace_name` | string | Yes | Human-readable name for the KV namespace. Must be unique within the Cloudflare account. Limited to 64 characters. |
+| `account_id` | string | Yes | The Cloudflare account ID (32 hex characters) that owns the namespace. |
 | `ttl_seconds` | int32 | No | Default TTL for key-value entries in seconds. Set to 0 (default) for no expiration. Minimum value is 60 seconds if set. |
 | `description` | string | No | Short description of the namespace's purpose. Max 256 characters. Useful for documentation. |
 

--- a/apis/org/openmcf/provider/cloudflare/cloudflarekvnamespace/v1/catalog-page.md
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarekvnamespace/v1/catalog-page.md
@@ -32,6 +32,7 @@ metadata:
     pulumi.openmcf.org/stack.name: dev.CloudflareKvNamespace.my-kv
 spec:
   namespaceName: my-kv-store
+  accountId: 0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d
 ```
 
 Deploy:
@@ -49,6 +50,7 @@ This creates a KV namespace titled `my-kv-store` in your Cloudflare account. Bin
 | Field | Type | Description | Validation |
 |-------|------|-------------|------------|
 | `namespaceName` | `string` | A human-readable name for the KV namespace. Must be unique within the Cloudflare account. | Required, max 64 characters |
+| `accountId` | `string` | The Cloudflare account ID that owns the namespace. | Required, 32 hex characters |
 
 ### Optional Fields
 
@@ -75,6 +77,7 @@ metadata:
     pulumi.openmcf.org/stack.name: dev.CloudflareKvNamespace.dev-cache
 spec:
   namespaceName: dev-cache
+  accountId: 0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d
 ```
 
 ### Session Store with TTL Hint
@@ -93,6 +96,7 @@ metadata:
     pulumi.openmcf.org/stack.name: prod.CloudflareKvNamespace.session-store
 spec:
   namespaceName: prod-session-store
+  accountId: 0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d
   ttlSeconds: 3600
   description: "Session data for authenticated users"
 ```
@@ -113,6 +117,7 @@ metadata:
     pulumi.openmcf.org/stack.name: prod.CloudflareKvNamespace.feature-flags
 spec:
   namespaceName: feature-flags-prod
+  accountId: 0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d
   description: "Global feature flags consumed by edge Workers"
 ```
 

--- a/apis/org/openmcf/provider/cloudflare/cloudflarekvnamespace/v1/docs/README.md
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarekvnamespace/v1/docs/README.md
@@ -467,7 +467,7 @@ OpenMCF abstracts Workers KV into a clean protobuf API that captures the 80% use
 
 ### The 80/20 Configuration
 
-The `CloudflareKvNamespaceSpec` includes just three fields:
+The `CloudflareKvNamespaceSpec` includes a small set of fields:
 
 **1. `namespace_name` (required)**
 - The human-readable identifier for the namespace
@@ -475,18 +475,23 @@ The `CloudflareKvNamespaceSpec` includes just three fields:
 - Limited to 64 characters
 - Example: `myapp-config-prod`
 
-**2. `ttl_seconds` (optional)**
+**2. `account_id` (required)**
+- The Cloudflare account ID (32 hex characters) that owns the namespace
+- A KV namespace is account-scoped, so the account must be specified
+- Example: `0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d`
+
+**3. `ttl_seconds` (optional)**
 - Default TTL for keys in this namespace (documentation/convention)
 - Minimum: 60 seconds (enforced by Cloudflare when writing keys)
 - Use `0` or omit for no default expiration
 - Example: `3600` (1 hour)
 
-**3. `description` (optional)**
+**4. `description` (optional)**
 - Short human-readable description of the namespace's purpose
 - Max 256 characters
 - Example: `"Feature flags and configuration for MyApp production"`
 
-**Rationale:** These three fields cover the vast majority of KV namespace configurations. We intentionally omit:
+**Rationale:** These fields cover the vast majority of KV namespace configurations. We intentionally omit:
 - **Network IDs:** Not applicable to Workers KV (unlike compute resources)
 - **Performance tiers:** KV has a single storage tier
 - **Access controls:** Managed via Cloudflare API tokens, not per-namespace
@@ -558,6 +563,7 @@ metadata:
   name: myapp-dev-alice
 spec:
   namespace_name: myapp-dev-alice
+  account_id: 0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d
   ttl_seconds: 300  # 5-minute default TTL for quick cache expiration
   description: "Alice's dev environment for MyApp"
 ```
@@ -580,6 +586,7 @@ metadata:
   name: myapp-config-staging
 spec:
   namespace_name: myapp-config-staging
+  account_id: 0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d
   ttl_seconds: 0  # No default expiration (persistent config)
   description: "Feature flags and configuration for MyApp staging"
 ```
@@ -604,6 +611,7 @@ metadata:
   name: myapp-config-prod
 spec:
   namespace_name: myapp-config-prod
+  account_id: 0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d
   ttl_seconds: 0  # Persistent configuration
   description: "Feature flags and application configuration (production)"
 ```
@@ -617,6 +625,7 @@ metadata:
   name: myapp-cache-prod
 spec:
   namespace_name: myapp-cache-prod
+  account_id: 0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d
   ttl_seconds: 3600  # 1-hour default TTL for cache entries
   description: "Cached API responses and transient data (production)"
 ```
@@ -630,6 +639,7 @@ metadata:
   name: myapp-session-prod
 spec:
   namespace_name: myapp-session-prod
+  account_id: 0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d
   ttl_seconds: 1800  # 30-minute session expiration
   description: "User session tokens and temporary auth data (production)"
 ```
@@ -732,7 +742,7 @@ wrangler kv:bulk import --namespace-id=$NEW_NAMESPACE_ID backup.json
 
 6. **Implement TTLs where appropriate.** Use expiration for ephemeral data (sessions, cache). Leave config data without TTL.
 
-7. **OpenMCF simplifies the API.** Three fields (`namespace_name`, `ttl_seconds`, `description`) cover 80% of use cases. Advanced patterns happen at the application layer, not in infrastructure config.
+7. **OpenMCF simplifies the API.** A small field set (`namespace_name`, `account_id`, `ttl_seconds`, `description`) covers 80% of use cases. Advanced patterns happen at the application layer, not in infrastructure config.
 
 ---
 

--- a/apis/org/openmcf/provider/cloudflare/cloudflarekvnamespace/v1/hack/manifest.yaml
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarekvnamespace/v1/hack/manifest.yaml
@@ -3,6 +3,7 @@ kind: CloudflareKvNamespace
 metadata:
   name: example-kv-namespace
 spec:
-  namespace_name: myapp-config-prod
-  ttl_seconds: 0  # No automatic expiration (persistent config)
+  namespaceName: myapp-config-prod
+  accountId: 0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d
+  ttlSeconds: 0  # No automatic expiration (persistent config)
   description: "Example KV namespace for feature flags and configuration"

--- a/apis/org/openmcf/provider/cloudflare/cloudflarekvnamespace/v1/iac/pulumi/module/kv_namespace.go
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarekvnamespace/v1/iac/pulumi/module/kv_namespace.go
@@ -15,10 +15,11 @@ func kvNamespace(
 
 	// Build the namespace arguments directly from proto fields.
 	kvArgs := &cloudflare.WorkersKvNamespaceArgs{
-		Title: pulumi.String(locals.CloudflareKvNamespace.Spec.NamespaceName),
+		AccountId: pulumi.String(locals.CloudflareKvNamespace.Spec.AccountId),
+		Title:     pulumi.String(locals.CloudflareKvNamespace.Spec.NamespaceName),
 		// NOTE:
-		// The Cloudflare Pulumi provider (v5) does not expose "ttl_seconds" or "description"
-		// fields on a KV namespace resource. These spec fields are therefore ignored.
+		// The Cloudflare KV namespace resource does not expose "ttl_seconds" or
+		// "description" fields, so those spec fields are not set here.
 	}
 
 	// Create the namespace.

--- a/apis/org/openmcf/provider/cloudflare/cloudflarekvnamespace/v1/iac/tf/README.md
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarekvnamespace/v1/iac/tf/README.md
@@ -1,0 +1,37 @@
+# Cloudflare KV Namespace - OpenTofu Module
+
+Provisions a Cloudflare Workers KV namespace (`cloudflare_workers_kv_namespace`) and
+exports its identifier for binding to Workers.
+
+## Inputs
+
+| Variable | Description |
+|----------|-------------|
+| `metadata` | Resource metadata (name, labels, ...). |
+| `spec.namespace_name` | Human-readable title for the KV namespace (max 64 chars). |
+| `spec.account_id` | Cloudflare account ID (32 hex characters) that owns the namespace. |
+| `spec.ttl_seconds` | Spec-level default TTL hint; not represented on the KV namespace resource. |
+| `spec.description` | Spec-level description; not represented on the KV namespace resource. |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `namespace_id` | The unique identifier of the created KV namespace. |
+
+## Provider
+
+```hcl
+terraform {
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "cloudflare" {
+  # Automatically uses CLOUDFLARE_API_TOKEN environment variable
+}
+```

--- a/apis/org/openmcf/provider/cloudflare/cloudflarekvnamespace/v1/iac/tf/locals.tf
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarekvnamespace/v1/iac/tf/locals.tf
@@ -1,0 +1,13 @@
+locals {
+  # Resource naming
+  resource_name = coalesce(try(var.metadata.name, null), "cloudflare-kv-namespace")
+
+  # Labels
+  labels = merge({
+    "name" = local.resource_name
+  }, try(var.metadata.labels, {}))
+
+  # Namespace configuration
+  namespace_name = var.spec.namespace_name
+  account_id     = var.spec.account_id
+}

--- a/apis/org/openmcf/provider/cloudflare/cloudflarekvnamespace/v1/iac/tf/main.tf
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarekvnamespace/v1/iac/tf/main.tf
@@ -1,0 +1,7 @@
+# Cloudflare Workers KV namespace.
+# ttl_seconds and description are part of the OpenMCF spec but have no
+# representation on the Cloudflare KV namespace resource, so they are not set.
+resource "cloudflare_workers_kv_namespace" "main" {
+  account_id = local.account_id
+  title      = local.namespace_name
+}

--- a/apis/org/openmcf/provider/cloudflare/cloudflarekvnamespace/v1/iac/tf/outputs.tf
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarekvnamespace/v1/iac/tf/outputs.tf
@@ -1,0 +1,4 @@
+output "namespace_id" {
+  description = "The unique identifier of the created KV namespace"
+  value       = cloudflare_workers_kv_namespace.main.id
+}

--- a/apis/org/openmcf/provider/cloudflare/cloudflarekvnamespace/v1/iac/tf/provider.tf
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarekvnamespace/v1/iac/tf/provider.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "cloudflare" {
+  # Cloudflare provider automatically uses CLOUDFLARE_API_TOKEN environment variable
+}

--- a/apis/org/openmcf/provider/cloudflare/cloudflarekvnamespace/v1/iac/tf/variables.tf
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarekvnamespace/v1/iac/tf/variables.tf
@@ -1,18 +1,31 @@
 variable "metadata" {
   description = "Metadata for the resource, including name and labels"
   type = object({
-    name = string,
-    id = optional(string),
-    org = optional(string),
-    env = optional(string),
-    labels = optional(map(string)),
-    tags = optional(list(string)),
+    name    = string
+    id      = optional(string)
+    org     = optional(string)
+    env     = optional(string)
+    labels  = optional(map(string))
+    tags    = optional(list(string))
     version = optional(object({ id = string, message = string }))
   })
 }
 
-
 variable "spec" {
-  description = "spec"
-  type = object({})
+  description = "Specification for the Cloudflare Workers KV namespace"
+  type = object({
+    # Human-readable name (title) for the KV namespace.
+    namespace_name = string
+
+    # Cloudflare account ID (32 hex characters) that owns the namespace.
+    account_id = string
+
+    # Default time-to-live for entries, in seconds. Not represented on the
+    # Cloudflare KV namespace resource itself; kept for spec completeness.
+    ttl_seconds = optional(number)
+
+    # Free-form description. Not represented on the Cloudflare KV namespace
+    # resource itself; kept for spec completeness.
+    description = optional(string)
+  })
 }

--- a/apis/org/openmcf/provider/cloudflare/cloudflarekvnamespace/v1/presets/01-standard.md
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarekvnamespace/v1/presets/01-standard.md
@@ -1,6 +1,6 @@
 # Standard KV Namespace
 
-Creates a Workers KV namespace for key-value storage. KV provides globally replicated, eventually consistent storage for Workers. Only three fields: name, ttl, and description.
+Creates a Workers KV namespace for key-value storage. KV provides globally replicated, eventually consistent storage for Workers. The namespace is created under the given Cloudflare account; the remaining fields are the name, ttl, and description.
 
 ## When to Use
 
@@ -13,10 +13,12 @@ Creates a Workers KV namespace for key-value storage. KV provides globally repli
 - **ttlSeconds** (`ttlSeconds: 0`) -- Default TTL for keys; 0 = never expire. Minimum 60 for expiring keys.
 - **description** (`description`) -- Optional; helps document the namespace's purpose.
 - **namespaceName** (`namespaceName`) -- Unique name within account; max 64 chars.
+- **accountId** (`accountId`) -- The Cloudflare account that owns the namespace.
 
 ## Placeholders to Replace
 
 | Placeholder | Description | Where to Find |
 |-------------|-------------|---------------|
 | `<namespace-name>` | Unique name for the KV namespace | Choose a descriptive name (e.g., app-cache, config-store) |
+| `<cloudflare-account-id>` | The Cloudflare account ID (32 hex characters) | Cloudflare dashboard -> account home (right sidebar), or `wrangler whoami` |
 | `<short-description>` | Brief description of the namespace | e.g., "API response cache for production" |

--- a/apis/org/openmcf/provider/cloudflare/cloudflarekvnamespace/v1/presets/01-standard.yaml
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarekvnamespace/v1/presets/01-standard.yaml
@@ -4,5 +4,6 @@ metadata:
   name: my-kv-namespace
 spec:
   namespaceName: <namespace-name>
+  accountId: <cloudflare-account-id>
   ttlSeconds: 0
   description: <short-description>

--- a/apis/org/openmcf/provider/cloudflare/cloudflarekvnamespace/v1/spec.pb.go
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarekvnamespace/v1/spec.pb.go
@@ -35,7 +35,9 @@ type CloudflareKvNamespaceSpec struct {
 	TtlSeconds int32 `protobuf:"varint,2,opt,name=ttl_seconds,json=ttlSeconds,proto3" json:"ttl_seconds,omitempty"`
 	// (Optional) A short description of the namespace.
 	// Useful for documentation or identifying the purpose of this KV store.
-	Description   string `protobuf:"bytes,3,opt,name=description,proto3" json:"description,omitempty"`
+	Description string `protobuf:"bytes,3,opt,name=description,proto3" json:"description,omitempty"`
+	// The Cloudflare account ID that owns this KV namespace.
+	AccountId     string `protobuf:"bytes,4,opt,name=account_id,json=accountId,proto3" json:"account_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -91,17 +93,26 @@ func (x *CloudflareKvNamespaceSpec) GetDescription() string {
 	return ""
 }
 
+func (x *CloudflareKvNamespaceSpec) GetAccountId() string {
+	if x != nil {
+		return x.AccountId
+	}
+	return ""
+}
+
 var File_org_openmcf_provider_cloudflare_cloudflarekvnamespace_v1_spec_proto protoreflect.FileDescriptor
 
 const file_org_openmcf_provider_cloudflare_cloudflarekvnamespace_v1_spec_proto_rawDesc = "" +
 	"\n" +
-	"Corg/openmcf/provider/cloudflare/cloudflarekvnamespace/v1/spec.proto\x128org.openmcf.provider.cloudflare.cloudflarekvnamespace.v1\x1a\x1bbuf/validate/validate.proto\"\xa4\x01\n" +
+	"Corg/openmcf/provider/cloudflare/cloudflarekvnamespace/v1/spec.proto\x128org.openmcf.provider.cloudflare.cloudflarekvnamespace.v1\x1a\x1bbuf/validate/validate.proto\"\xe3\x01\n" +
 	"\x19CloudflareKvNamespaceSpec\x121\n" +
 	"\x0enamespace_name\x18\x01 \x01(\tB\n" +
 	"\xbaH\a\xc8\x01\x01r\x02\x18@R\rnamespaceName\x12(\n" +
 	"\vttl_seconds\x18\x02 \x01(\x05B\a\xbaH\x04\x1a\x02(\x00R\n" +
 	"ttlSeconds\x12*\n" +
-	"\vdescription\x18\x03 \x01(\tB\b\xbaH\x05r\x03\x18\x80\x02R\vdescriptionB\xc4\x03\n" +
+	"\vdescription\x18\x03 \x01(\tB\b\xbaH\x05r\x03\x18\x80\x02R\vdescription\x12=\n" +
+	"\n" +
+	"account_id\x18\x04 \x01(\tB\x1e\xbaH\x1b\xc8\x01\x01r\x162\x11^[0-9a-fA-F]{32}$\x98\x01 R\taccountIdB\xc4\x03\n" +
 	"<com.org.openmcf.provider.cloudflare.cloudflarekvnamespace.v1B\tSpecProtoP\x01Zrgithub.com/plantonhq/openmcf/apis/org/openmcf/provider/cloudflare/cloudflarekvnamespace/v1;cloudflarekvnamespacev1\xa2\x02\x05OOPCC\xaa\x028Org.Openmcf.Provider.Cloudflare.Cloudflarekvnamespace.V1\xca\x028Org\\Openmcf\\Provider\\Cloudflare\\Cloudflarekvnamespace\\V1\xe2\x02DOrg\\Openmcf\\Provider\\Cloudflare\\Cloudflarekvnamespace\\V1\\GPBMetadata\xea\x02=Org::Openmcf::Provider::Cloudflare::Cloudflarekvnamespace::V1b\x06proto3"
 
 var (

--- a/apis/org/openmcf/provider/cloudflare/cloudflarekvnamespace/v1/spec.proto
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarekvnamespace/v1/spec.proto
@@ -22,4 +22,11 @@ message CloudflareKvNamespaceSpec {
   // (Optional) A short description of the namespace.
   // Useful for documentation or identifying the purpose of this KV store.
   string description = 3 [(buf.validate.field).string.max_len = 256];
+
+  // The Cloudflare account ID that owns this KV namespace.
+  string account_id = 4 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.len = 32,
+    (buf.validate.field).string.pattern = "^[0-9a-fA-F]{32}$"
+  ];
 }

--- a/apis/org/openmcf/provider/cloudflare/cloudflarekvnamespace/v1/spec_test.go
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarekvnamespace/v1/spec_test.go
@@ -28,10 +28,47 @@ var _ = ginkgo.Describe("CloudflareKvNamespaceSpec Custom Validation Tests", fun
 					},
 					Spec: &CloudflareKvNamespaceSpec{
 						NamespaceName: "test-namespace",
+						AccountId:     "0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d",
 					},
 				}
 				err := protovalidate.Validate(input)
 				gomega.Expect(err).To(gomega.BeNil())
+			})
+		})
+	})
+
+	ginkgo.Describe("When invalid input is passed", func() {
+		ginkgo.Context("cloudflare_kv_namespace", func() {
+
+			ginkgo.It("should return a validation error when account_id is missing", func() {
+				input := &CloudflareKvNamespace{
+					ApiVersion: "cloudflare.openmcf.org/v1",
+					Kind:       "CloudflareKvNamespace",
+					Metadata: &shared.CloudResourceMetadata{
+						Name: "test-kv-namespace",
+					},
+					Spec: &CloudflareKvNamespaceSpec{
+						NamespaceName: "test-namespace",
+					},
+				}
+				err := protovalidate.Validate(input)
+				gomega.Expect(err).NotTo(gomega.BeNil())
+			})
+
+			ginkgo.It("should return a validation error when account_id is not 32 hex characters", func() {
+				input := &CloudflareKvNamespace{
+					ApiVersion: "cloudflare.openmcf.org/v1",
+					Kind:       "CloudflareKvNamespace",
+					Metadata: &shared.CloudResourceMetadata{
+						Name: "test-kv-namespace",
+					},
+					Spec: &CloudflareKvNamespaceSpec{
+						NamespaceName: "test-namespace",
+						AccountId:     "not-a-valid-account-id",
+					},
+				}
+				err := protovalidate.Validate(input)
+				gomega.Expect(err).NotTo(gomega.BeNil())
 			})
 		})
 	})

--- a/apis/org/openmcf/provider/cloudflare/cloudflareloadbalancer/v1/docs/README.md
+++ b/apis/org/openmcf/provider/cloudflare/cloudflareloadbalancer/v1/docs/README.md
@@ -129,12 +129,14 @@ resource "cloudflare_load_balancer_pool" "primary" {
   account_id       = var.cloudflare_account_id
   name             = "primary-pool-us-east"
   monitor          = cloudflare_load_balancer_monitor.http_check.id
-  
-  origins {
-    name    = "primary-origin-1"
-    address = "198.51.100.1"
-    enabled = true
-  }
+
+  origins = [
+    {
+      name    = "primary-origin-1"
+      address = "198.51.100.1"
+      enabled = true
+    }
+  ]
 }
 
 # 3. Define the Secondary/Backup Pool (Account-level)
@@ -142,12 +144,14 @@ resource "cloudflare_load_balancer_pool" "secondary" {
   account_id       = var.cloudflare_account_id
   name             = "secondary-pool-us-west"
   monitor          = cloudflare_load_balancer_monitor.http_check.id
-  
-  origins {
-    name    = "backup-origin-1"
-    address = "198.51.100.2"
-    enabled = true
-  }
+
+  origins = [
+    {
+      name    = "backup-origin-1"
+      address = "198.51.100.2"
+      enabled = true
+    }
+  ]
 }
 
 # 4. Define the Load Balancer (Zone-level)
@@ -160,13 +164,13 @@ resource "cloudflare_load_balancer" "failover_lb" {
   steering_policy = "off"
   
   # Failover priority: primary -> secondary
-  default_pool_ids = [
+  default_pools = [
     cloudflare_load_balancer_pool.primary.id,
     cloudflare_load_balancer_pool.secondary.id
   ]
   
   # Pool of last resort. If both primary and secondary fail, send here.
-  fallback_pool_id = cloudflare_load_balancer_pool.secondary.id
+  fallback_pool = cloudflare_load_balancer_pool.secondary.id
   
   # Enable sticky sessions
   session_affinity = "cookie"
@@ -344,10 +348,10 @@ A user on a Pro plan *cannot* achieve a failover time of less than 60 seconds. T
 **Active-Passive Failover** is the most common resilience pattern. The configuration is counter-intuitive:
 
 1. `steering_policy` must be set to **`"off"`** (not `"failover"`)
-2. The `default_pool_ids` list is treated as an **ordered priority list**
+2. The `default_pools` list is treated as an **ordered priority list**
 3. Traffic is sent *only* to the first healthy pool in the list
 
-**Fallback Pool**: A `fallback_pool_id` is required. This is the pool of last resort. If all pools in the `default_pool_ids` list are marked unhealthy, Cloudflare will send all traffic to the `fallback_pool_id` *regardless of its own health status*. This ensures traffic continues flowing, even if it's to a degraded origin.
+**Fallback Pool**: A `fallback_pool` is required. This is the pool of last resort. If all pools in the `default_pools` list are marked unhealthy, Cloudflare will send all traffic to the `fallback_pool` *regardless of its own health status*. This ensures traffic continues flowing, even if it's to a degraded origin.
 
 **Failback**: When a higher-priority pool (e.g., the primary pool) recovers and is marked healthy again, the load balancer will automatically "fail back," shifting traffic away from the passive pool and back to the primary.
 
@@ -355,7 +359,7 @@ A user on a Pro plan *cannot* achieve a failover time of less than 60 seconds. T
 
 The `steering_policy` parameter dictates how the load balancer selects a pool:
 
-- **`"off"`** (Default): Disables dynamic steering and enables Active-Passive Failover. Uses `default_pool_ids` as a static failover priority.
+- **`"off"`** (Default): Disables dynamic steering and enables Active-Passive Failover. Uses `default_pools` as a static failover priority.
 - **`"random"`**: Distributes traffic randomly across pools based on configured weights. Used for active-active load balancing or A/B testing.
 - **`"geo"`**: Steers traffic based on the user's geographic location, matching it against `region_pools` or `country_pools` maps.
 - **`"dynamic_latency"`** (Enterprise only): Steers traffic to the pool with the lowest measured Round Trip Time (RTT) from the Cloudflare edge PoP.
@@ -376,7 +380,7 @@ Session affinity ensures that subsequent requests from the same end-user are "st
 - **Response Code Mismatch**: The monitor expects `expected_codes = "200"`, but the origin's health endpoint issues an HTTP 301 or 302 redirect. Solution: Set `follow_redirects = true` on the monitor.
 - **TLS Mismatch**: An HTTPS monitor is used against an origin with a self-signed or invalid certificate. The TLS handshake fails. Solution: Use a free Cloudflare Origin CA certificate on the origin or, if security is not paramount, set `allow_insecure = true` on the monitor.
 
-**No Fallback Pool**: Failing to define a `fallback_pool_id`. If all `default_pool_ids` become unhealthy, there is no "pool of last resort," and users will receive an error (e.g., HTTP 530).
+**No Fallback Pool**: Failing to define a `fallback_pool`. If all `default_pools` become unhealthy, there is no "pool of last resort," and users will receive an error (e.g., HTTP 530).
 
 **Single Origin**: Configuring a load balancer with a single pool containing only one origin. This provides no resilience, no failover, and serves no purpose beyond that of a standard DNS record.
 
@@ -512,8 +516,8 @@ Behind the scenes, the OpenMCF controller:
 2. Creates two Cloudflare Pools (one for each origin), both referencing the Monitor
 3. Creates a Cloudflare Load Balancer with:
    - `steering_policy = "off"`
-   - `default_pool_ids` set to the primary pool ID (index 0) and secondary pool ID (index 1)
-   - `fallback_pool_id` set to the secondary pool ID
+   - `default_pools` set to the primary pool ID (index 0) and secondary pool ID (index 1)
+   - `fallback_pool` set to the secondary pool ID
    - `session_affinity = "cookie"`
 
 The user sees a simple, intuitive API. OpenMCF handles the complexity.
@@ -528,7 +532,7 @@ The API design makes correct configuration easy and incorrect configuration diff
 
 Future enhancements can add:
 - Validation to require at least two origins for production environments
-- Auto-configuration of `fallback_pool_id` to the last origin in the list
+- Auto-configuration of `fallback_pool` to the last origin in the list
 - Built-in geo-routing templates (e.g., "US-East + US-West + EU")
 
 ---

--- a/apis/org/openmcf/provider/cloudflare/cloudflareloadbalancer/v1/hack/manifest.yaml
+++ b/apis/org/openmcf/provider/cloudflare/cloudflareloadbalancer/v1/hack/manifest.yaml
@@ -1,5 +1,19 @@
 apiVersion: cloudflare.openmcf.org/v1
 kind: CloudflareLoadBalancer
 metadata:
-  name: first-certificate
+  name: lb-hack
 spec:
+  hostname: lb.openmcf-example.com
+  zone_id:
+    value: "0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d"
+  origins:
+    - name: origin-1
+      address: 192.0.2.10
+      weight: 1
+    - name: origin-2
+      address: 192.0.2.11
+      weight: 1
+  proxied: true
+  healthProbePath: /healthz
+  sessionAffinity: cookie
+  steeringPolicy: random

--- a/apis/org/openmcf/provider/cloudflare/cloudflareloadbalancer/v1/iac/pulumi/module/load_balancer.go
+++ b/apis/org/openmcf/provider/cloudflare/cloudflareloadbalancer/v1/iac/pulumi/module/load_balancer.go
@@ -19,17 +19,34 @@ func load_balancer(
 	cloudflareProvider *cloudflare.Provider,
 ) (*cloudflare.LoadBalancer, error) {
 
+	resourceName := locals.CloudflareLoadBalancer.Metadata.Name
+
+	// The load balancer is zone-scoped, while the pool and monitor are
+	// account-scoped. Derive the account id from the zone so the spec only
+	// needs the zone reference.
+	zoneId := locals.CloudflareLoadBalancer.Spec.ZoneId.GetValue()
+	zone, err := cloudflare.LookupZone(ctx, &cloudflare.LookupZoneArgs{
+		ZoneId: pulumi.StringRef(zoneId),
+	}, pulumi.Provider(cloudflareProvider))
+	if err != nil {
+		return nil, fmt.Errorf("failed to look up zone for account id: %w", err)
+	}
+	accountId := zone.Account.Id
+
 	// ---------------------------------------------------------------------
 	// 1. Monitor (health check) – uses the health_probe_path from the spec.
 	// ---------------------------------------------------------------------
 	createdMonitor, err := cloudflare.NewLoadBalancerMonitor(ctx, "monitor",
 		&cloudflare.LoadBalancerMonitorArgs{
-			Type:          pulumi.String("http"),
+			AccountId:     pulumi.String(accountId),
+			Type:          pulumi.String("https"),
 			Method:        pulumi.String("GET"),
 			Path:          pulumi.String(locals.CloudflareLoadBalancer.Spec.HealthProbePath),
-			Retries:       pulumi.Int(2),
-			Timeout:       pulumi.Int(5),
 			ExpectedCodes: pulumi.String("2xx"),
+			Timeout:       pulumi.Int(5),
+			Interval:      pulumi.Int(60),
+			Retries:       pulumi.Int(2),
+			Description:   pulumi.String(fmt.Sprintf("Health check for %s", resourceName)),
 		}, pulumi.Provider(cloudflareProvider))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create monitor: %w", err)
@@ -43,15 +60,18 @@ func load_balancer(
 		poolOrigins = append(poolOrigins, cloudflare.LoadBalancerPoolOriginArgs{
 			Name:    pulumi.String(o.Name),
 			Address: pulumi.String(o.Address),
+			Enabled: pulumi.Bool(true),
 			Weight:  pulumi.Float64Ptr(float64(o.Weight)),
 		})
 	}
 
 	createdPool, err := cloudflare.NewLoadBalancerPool(ctx, "pool", &cloudflare.LoadBalancerPoolArgs{
-		Name:    pulumi.String(locals.CloudflareLoadBalancer.Metadata.Name + "-pool"),
-		Origins: poolOrigins,
-		Monitor: createdMonitor.ID(),
-		Enabled: pulumi.Bool(true),
+		AccountId:   pulumi.String(accountId),
+		Name:        pulumi.String(resourceName + "-pool"),
+		Origins:     poolOrigins,
+		Monitor:     createdMonitor.ID(),
+		Enabled:     pulumi.Bool(true),
+		Description: pulumi.String(fmt.Sprintf("Pool for %s", resourceName)),
 	}, pulumi.Provider(cloudflareProvider))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create pool: %w", err)
@@ -66,13 +86,14 @@ func load_balancer(
 	affinity := pulumi.StringPtr(locals.CloudflareLoadBalancer.Spec.SessionAffinity.String())
 
 	createdLoadBalancer, err := cloudflare.NewLoadBalancer(ctx, "load_balancer", &cloudflare.LoadBalancerArgs{
-		ZoneId:          pulumi.String(locals.CloudflareLoadBalancer.Spec.ZoneId.GetValue()),
+		ZoneId:          pulumi.String(zoneId),
 		Name:            pulumi.String(locals.CloudflareLoadBalancer.Spec.Hostname),
 		DefaultPools:    pulumi.StringArray{createdPool.ID()},
 		FallbackPool:    createdPool.ID(),
 		Proxied:         pulumi.BoolPtr(locals.CloudflareLoadBalancer.Spec.Proxied),
 		SteeringPolicy:  steering,
 		SessionAffinity: affinity,
+		Description:     pulumi.String(fmt.Sprintf("Load balancer for %s", locals.CloudflareLoadBalancer.Spec.Hostname)),
 	}, pulumi.Provider(cloudflareProvider))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create load balancer: %w", err)
@@ -83,7 +104,7 @@ func load_balancer(
 	// ---------------------------------------------------------------------
 	ctx.Export(OpLoadBalancerId, createdLoadBalancer.ID())
 	ctx.Export(OpLoadBalancerDnsRecordName, pulumi.String(locals.CloudflareLoadBalancer.Spec.Hostname))
-	ctx.Export(OpLoadBalancerCnameTarget, createdLoadBalancer.Name)
+	ctx.Export(OpLoadBalancerCnameTarget, createdLoadBalancer.ID())
 
 	return createdLoadBalancer, nil
 }

--- a/apis/org/openmcf/provider/cloudflare/cloudflareloadbalancer/v1/iac/tf/README.md
+++ b/apis/org/openmcf/provider/cloudflare/cloudflareloadbalancer/v1/iac/tf/README.md
@@ -61,7 +61,7 @@ terraform {
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/apis/org/openmcf/provider/cloudflare/cloudflareloadbalancer/v1/iac/tf/locals.tf
+++ b/apis/org/openmcf/provider/cloudflare/cloudflareloadbalancer/v1/iac/tf/locals.tf
@@ -7,8 +7,8 @@ locals {
     "name" = local.resource_name
   }, try(var.metadata.labels, {}))
 
-  # Zone ID - resolve from value or ref
-  zone_id = coalesce(try(var.spec.zone_id.value, null), try(var.spec.zone_id.ref, null))
+  # Zone ID (StringValueOrRef flattened to a plain string by the converter)
+  zone_id = try(var.spec.zone_id, "")
 
   # Health probe path with default
   health_probe_path = coalesce(try(var.spec.health_probe_path, null), "/")
@@ -16,20 +16,10 @@ locals {
   # Proxied setting with default
   proxied = coalesce(try(var.spec.proxied, null), true)
 
-  # Session affinity mapping (enum to string)
-  session_affinity_map = {
-    0 = "none"
-    1 = "cookie"
-  }
-  session_affinity = lookup(local.session_affinity_map, try(var.spec.session_affinity, 0), "none")
-
-  # Steering policy mapping (enum to string)
-  steering_policy_map = {
-    0 = "off"     # STEERING_OFF - active-passive failover
-    1 = "geo"     # STEERING_GEO - geographic routing
-    2 = "random"  # STEERING_RANDOM - weighted distribution
-  }
-  steering_policy = lookup(local.steering_policy_map, try(var.spec.steering_policy, 0), "off")
+  # Session affinity and steering policy: the enum flattens to its string name,
+  # which matches the value Cloudflare expects directly.
+  session_affinity = coalesce(try(var.spec.session_affinity, null), "none")
+  steering_policy   = coalesce(try(var.spec.steering_policy, null), "off")
 
   # Origins list
   origins = try(var.spec.origins, [])

--- a/apis/org/openmcf/provider/cloudflare/cloudflareloadbalancer/v1/iac/tf/main.tf
+++ b/apis/org/openmcf/provider/cloudflare/cloudflareloadbalancer/v1/iac/tf/main.tf
@@ -1,12 +1,19 @@
+# The load balancer is zone-scoped, while the pool and monitor are account-scoped.
+# Derive the account id from the zone so the spec only needs the zone reference.
+data "cloudflare_zone" "this" {
+  zone_id = local.zone_id
+}
+
 # Cloudflare Load Balancer Monitor (Health Check)
 # This is an account-level resource that probes origins
 resource "cloudflare_load_balancer_monitor" "health_check" {
+  account_id     = data.cloudflare_zone.this.account.id
   type           = "https"
   method         = "GET"
   path           = local.health_probe_path
   expected_codes = "2xx"
   timeout        = 5
-  interval       = 60  # 60 seconds minimum for Pro plan
+  interval       = 60 # 60 seconds minimum for Pro plan
   retries        = 2
 
   description = "Health check for ${local.resource_name}"
@@ -15,20 +22,20 @@ resource "cloudflare_load_balancer_monitor" "health_check" {
 # Cloudflare Load Balancer Pool
 # This is an account-level resource that groups origins
 resource "cloudflare_load_balancer_pool" "main" {
-  name    = "${local.resource_name}-pool"
-  monitor = cloudflare_load_balancer_monitor.health_check.id
-  enabled = true
+  account_id = data.cloudflare_zone.this.account.id
+  name       = "${local.resource_name}-pool"
+  monitor    = cloudflare_load_balancer_monitor.health_check.id
+  enabled    = true
 
-  # Create an origin block for each origin in the spec
-  dynamic "origins" {
-    for_each = local.origins
-    content {
-      name    = origins.value.name
-      address = origins.value.address
+  # One origin object per origin in the spec
+  origins = [
+    for o in local.origins : {
+      name    = o.name
+      address = o.address
       enabled = true
-      weight  = coalesce(origins.value.weight, 1)
+      weight  = coalesce(o.weight, 1)
     }
-  }
+  ]
 
   description = "Pool for ${local.resource_name}"
 }
@@ -40,8 +47,8 @@ resource "cloudflare_load_balancer" "main" {
   name    = var.spec.hostname
 
   # Pool configuration
-  default_pool_ids = [cloudflare_load_balancer_pool.main.id]
-  fallback_pool_id = cloudflare_load_balancer_pool.main.id
+  default_pools = [cloudflare_load_balancer_pool.main.id]
+  fallback_pool = cloudflare_load_balancer_pool.main.id
 
   # Proxy configuration
   proxied = local.proxied
@@ -54,9 +61,8 @@ resource "cloudflare_load_balancer" "main" {
 
   description = "Load balancer for ${var.spec.hostname}"
 
-  # Wait for the pool to be healthy before creating the load balancer
+  # Wait for the pool to be created before creating the load balancer
   depends_on = [
     cloudflare_load_balancer_pool.main
   ]
 }
-

--- a/apis/org/openmcf/provider/cloudflare/cloudflareloadbalancer/v1/iac/tf/outputs.tf
+++ b/apis/org/openmcf/provider/cloudflare/cloudflareloadbalancer/v1/iac/tf/outputs.tf
@@ -9,17 +9,6 @@ output "load_balancer_dns_record_name" {
 }
 
 output "load_balancer_cname_target" {
-  description = "The CNAME target returned by Cloudflare for the load balancer"
+  description = "The stable identifier the load balancer hostname resolves to"
   value       = cloudflare_load_balancer.main.id
 }
-
-output "pool_id" {
-  description = "The ID of the load balancer pool"
-  value       = cloudflare_load_balancer_pool.main.id
-}
-
-output "monitor_id" {
-  description = "The ID of the health check monitor"
-  value       = cloudflare_load_balancer_monitor.health_check.id
-}
-

--- a/apis/org/openmcf/provider/cloudflare/cloudflareloadbalancer/v1/iac/tf/provider.tf
+++ b/apis/org/openmcf/provider/cloudflare/cloudflareloadbalancer/v1/iac/tf/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/apis/org/openmcf/provider/cloudflare/cloudflareloadbalancer/v1/iac/tf/variables.tf
+++ b/apis/org/openmcf/provider/cloudflare/cloudflareloadbalancer/v1/iac/tf/variables.tf
@@ -17,11 +17,9 @@ variable "spec" {
     # The DNS hostname for the load balancer (e.g., "app.example.com")
     hostname = string
 
-    # Foreign key reference to a Cloudflare DNS zone
-    zone_id = object({
-      value = optional(string)
-      ref   = optional(string)
-    })
+    # Foreign key reference to a Cloudflare DNS zone (StringValueOrRef flattened
+    # to a plain string by the tfvars converter).
+    zone_id = optional(string)
 
     # List of origin servers behind this load balancer
     origins = list(object({
@@ -36,10 +34,10 @@ variable "spec" {
     # HTTP path to use for health monitoring of origins
     health_probe_path = optional(string, "/")
 
-    # Session affinity setting (0 = none, 1 = cookie)
-    session_affinity = optional(number, 0)
+    # Session affinity setting ("none" or "cookie"); enum flattens to its string name.
+    session_affinity = optional(string, "none")
 
-    # Traffic steering policy (0 = off/failover, 1 = geo, 2 = random)
-    steering_policy = optional(number, 0)
+    # Traffic steering policy ("off"/failover, "geo", or "random"); enum flattens to its string name.
+    steering_policy = optional(string, "off")
   })
 }

--- a/apis/org/openmcf/provider/cloudflare/cloudflareruleset/v1/iac/hack/manifest.yaml
+++ b/apis/org/openmcf/provider/cloudflare/cloudflareruleset/v1/iac/hack/manifest.yaml
@@ -3,7 +3,8 @@ kind: CloudflareRuleset
 metadata:
   name: test-origin-rule
 spec:
-  zone_id: "test-zone-id-abc123"
+  zone_id:
+    value: "0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d"
   ruleset_kind: zone
   phase: http_request_origin
   name: "Test origin routing"

--- a/apis/org/openmcf/provider/cloudflare/cloudflareruleset/v1/iac/tf/README.md
+++ b/apis/org/openmcf/provider/cloudflare/cloudflareruleset/v1/iac/tf/README.md
@@ -58,10 +58,13 @@ module "origin_rule" {
 | `zone_id` | Zone ID (pass-through) |
 | `phase` | Phase (pass-through) |
 
-## Dynamic Blocks
+## Rule and Action Parameter Construction
 
-The `main.tf` uses Terraform dynamic blocks extensively to handle the optional nature of action parameters. Each action type's parameters are wrapped in `dynamic` blocks that only render when the corresponding fields are non-null.
+The `main.tf` builds the `rules` list and each rule's `action_parameters` using attribute
+(object) syntax. Optional nested attributes are emitted as `null` when the corresponding spec
+fields are absent, so only the parameters relevant to each rule's action are sent to Cloudflare.
 
 ## Provider Version
 
-Uses `cloudflare/cloudflare ~> 4.0`. The `cloudflare_ruleset` resource is available in all 4.x versions.
+Uses `cloudflare/cloudflare ~> 5.0`. In provider v5 the `cloudflare_ruleset` rules and action
+parameters are nested attributes (assigned with object syntax), not nested blocks.

--- a/apis/org/openmcf/provider/cloudflare/cloudflareruleset/v1/iac/tf/locals.tf
+++ b/apis/org/openmcf/provider/cloudflare/cloudflareruleset/v1/iac/tf/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  zone_id      = try(var.spec.zone_id.value, "")
+  zone_id      = try(var.spec.zone_id, "")
   account_id   = var.spec.account_id
   ruleset_kind = var.spec.ruleset_kind
   phase        = var.spec.phase

--- a/apis/org/openmcf/provider/cloudflare/cloudflareruleset/v1/iac/tf/main.tf
+++ b/apis/org/openmcf/provider/cloudflare/cloudflareruleset/v1/iac/tf/main.tf
@@ -6,176 +6,127 @@ resource "cloudflare_ruleset" "main" {
   name        = var.spec.name
   description = var.spec.description
 
-  dynamic "rules" {
-    for_each = var.spec.rules
-    content {
-      ref         = rules.value.ref != "" ? rules.value.ref : null
-      expression  = rules.value.expression
-      action      = rules.value.action
-      description = rules.value.description != "" ? rules.value.description : null
-      enabled     = rules.value.enabled
+  rules = [
+    for r in var.spec.rules : {
+      ref         = r.ref != "" ? r.ref : null
+      expression  = r.expression
+      action      = r.action
+      description = r.description != "" ? r.description : null
+      enabled     = r.enabled
 
-      dynamic "action_parameters" {
-        for_each = rules.value.action_parameters != null ? [rules.value.action_parameters] : []
-        content {
-          # Origin Rules (route)
-          host_header = action_parameters.value.host_header
+      action_parameters = r.action_parameters == null ? null : {
+        # Origin Rules (route)
+        host_header = r.action_parameters.host_header
 
-          dynamic "origin" {
-            for_each = action_parameters.value.origin != null ? [action_parameters.value.origin] : []
-            content {
-              host = origin.value.host
-              port = origin.value.port
-            }
+        origin = r.action_parameters.origin == null ? null : {
+          host = r.action_parameters.origin.host
+          port = r.action_parameters.origin.port
+        }
+
+        sni = r.action_parameters.sni == null ? null : {
+          value = r.action_parameters.sni.value
+        }
+
+        # Block
+        response = r.action_parameters.response == null ? null : {
+          status_code  = r.action_parameters.response.status_code
+          content      = r.action_parameters.response.content
+          content_type = r.action_parameters.response.content_type
+        }
+
+        # Rewrite
+        uri = r.action_parameters.uri == null ? null : {
+          path = r.action_parameters.uri.path == null ? null : {
+            value      = r.action_parameters.uri.path.value != "" ? r.action_parameters.uri.path.value : null
+            expression = r.action_parameters.uri.path.expression != "" ? r.action_parameters.uri.path.expression : null
           }
-
-          dynamic "sni" {
-            for_each = action_parameters.value.sni != null ? [action_parameters.value.sni] : []
-            content {
-              value = sni.value.value
-            }
+          query = r.action_parameters.uri.query == null ? null : {
+            value      = r.action_parameters.uri.query.value != "" ? r.action_parameters.uri.query.value : null
+            expression = r.action_parameters.uri.query.expression != "" ? r.action_parameters.uri.query.expression : null
           }
+        }
 
-          # Block
-          dynamic "response" {
-            for_each = action_parameters.value.response != null ? [action_parameters.value.response] : []
-            content {
-              status_code  = response.value.status_code
-              content      = response.value.content
-              content_type = response.value.content_type
-            }
+        # Header transforms: the v5 map key is the header name.
+        headers = length(r.action_parameters.headers) > 0 ? {
+          for name, h in r.action_parameters.headers : name => {
+            operation  = h.operation
+            value      = h.value != "" ? h.value : null
+            expression = h.expression != "" ? h.expression : null
           }
+        } : null
 
-          # Rewrite
-          dynamic "uri" {
-            for_each = action_parameters.value.uri != null ? [action_parameters.value.uri] : []
-            content {
-              dynamic "path" {
-                for_each = uri.value.path != null ? [uri.value.path] : []
-                content {
-                  value      = path.value.value != "" ? path.value.value : null
-                  expression = path.value.expression != "" ? path.value.expression : null
-                }
-              }
-              dynamic "query" {
-                for_each = uri.value.query != null ? [uri.value.query] : []
-                content {
-                  value      = query.value.value != "" ? query.value.value : null
-                  expression = query.value.expression != "" ? query.value.expression : null
-                }
-              }
-            }
+        # Redirect
+        from_value = r.action_parameters.from_value == null ? null : {
+          status_code           = r.action_parameters.from_value.status_code
+          preserve_query_string = r.action_parameters.from_value.preserve_query_string
+          target_url = {
+            value      = r.action_parameters.from_value.target_url.value != "" ? r.action_parameters.from_value.target_url.value : null
+            expression = r.action_parameters.from_value.target_url.expression != "" ? r.action_parameters.from_value.target_url.expression : null
           }
+        }
 
-          dynamic "headers" {
-            for_each = action_parameters.value.headers
-            content {
-              name       = headers.key
-              operation  = headers.value.operation
-              value      = headers.value.value != "" ? headers.value.value : null
-              expression = headers.value.expression != "" ? headers.value.expression : null
+        # Skip
+        phases   = length(r.action_parameters.phases) > 0 ? r.action_parameters.phases : null
+        products = length(r.action_parameters.products) > 0 ? r.action_parameters.products : null
+        ruleset  = r.action_parameters.ruleset != "" ? r.action_parameters.ruleset : null
+        rulesets = length(r.action_parameters.rulesets) > 0 ? r.action_parameters.rulesets : null
+
+        # Execute
+        id = r.action_parameters.id != "" ? r.action_parameters.id : null
+
+        overrides = r.action_parameters.overrides == null ? null : {
+          action            = r.action_parameters.overrides.action != "" ? r.action_parameters.overrides.action : null
+          enabled           = r.action_parameters.overrides.enabled
+          sensitivity_level = r.action_parameters.overrides.sensitivity_level != "" ? r.action_parameters.overrides.sensitivity_level : null
+
+          categories = length(r.action_parameters.overrides.categories) > 0 ? [
+            for c in r.action_parameters.overrides.categories : {
+              category          = c.category
+              action            = c.action
+              enabled           = c.enabled
+              sensitivity_level = c.sensitivity_level != "" ? c.sensitivity_level : null
             }
-          }
+          ] : null
 
-          # Redirect
-          dynamic "from_value" {
-            for_each = action_parameters.value.from_value != null ? [action_parameters.value.from_value] : []
-            content {
-              status_code          = from_value.value.status_code
-              preserve_query_string = from_value.value.preserve_query_string
-
-              dynamic "target_url" {
-                for_each = from_value.value.target_url != null ? [from_value.value.target_url] : []
-                content {
-                  value      = target_url.value.value != "" ? target_url.value.value : null
-                  expression = target_url.value.expression != "" ? target_url.value.expression : null
-                }
-              }
+          rules = length(r.action_parameters.overrides.rules) > 0 ? [
+            for ru in r.action_parameters.overrides.rules : {
+              id                = ru.id
+              action            = ru.action
+              enabled           = ru.enabled
+              score_threshold   = ru.score_threshold > 0 ? ru.score_threshold : null
+              sensitivity_level = ru.sensitivity_level != "" ? ru.sensitivity_level : null
             }
-          }
+          ] : null
+        }
 
-          # Skip
-          phases   = length(action_parameters.value.phases) > 0 ? action_parameters.value.phases : null
-          products = length(action_parameters.value.products) > 0 ? action_parameters.value.products : null
-          ruleset  = action_parameters.value.ruleset != "" ? action_parameters.value.ruleset : null
-          rulesets = length(action_parameters.value.rulesets) > 0 ? action_parameters.value.rulesets : null
+        # Cache
+        cache = r.action_parameters.cache
 
-          # Execute
-          id = action_parameters.value.id != "" ? action_parameters.value.id : null
+        edge_ttl = r.action_parameters.edge_ttl == null ? null : {
+          mode    = r.action_parameters.edge_ttl.mode
+          default = r.action_parameters.edge_ttl.default_ttl > 0 ? r.action_parameters.edge_ttl.default_ttl : null
 
-          dynamic "overrides" {
-            for_each = action_parameters.value.overrides != null ? [action_parameters.value.overrides] : []
-            content {
-              action            = overrides.value.action != "" ? overrides.value.action : null
-              enabled           = overrides.value.enabled
-              sensitivity_level = overrides.value.sensitivity_level != "" ? overrides.value.sensitivity_level : null
-
-              dynamic "categories" {
-                for_each = overrides.value.categories
-                content {
-                  category          = categories.value.category
-                  action            = categories.value.action
-                  enabled           = categories.value.enabled
-                  sensitivity_level = categories.value.sensitivity_level != "" ? categories.value.sensitivity_level : null
-                }
-              }
-
-              dynamic "rules" {
-                for_each = overrides.value.rules
-                content {
-                  id                = rules.value.id
-                  action            = rules.value.action
-                  enabled           = rules.value.enabled
-                  score_threshold   = rules.value.score_threshold > 0 ? rules.value.score_threshold : null
-                  sensitivity_level = rules.value.sensitivity_level != "" ? rules.value.sensitivity_level : null
-                }
+          status_code_ttl = length(r.action_parameters.edge_ttl.status_code_ttls) > 0 ? [
+            for s in r.action_parameters.edge_ttl.status_code_ttls : {
+              value       = s.value
+              status_code = s.status_code
+              status_code_range = s.status_code_range == null ? null : {
+                from = s.status_code_range.from
+                to   = s.status_code_range.to
               }
             }
-          }
+          ] : null
+        }
 
-          # Cache
-          cache = action_parameters.value.cache
+        browser_ttl = r.action_parameters.browser_ttl == null ? null : {
+          mode    = r.action_parameters.browser_ttl.mode
+          default = r.action_parameters.browser_ttl.default_ttl > 0 ? r.action_parameters.browser_ttl.default_ttl : null
+        }
 
-          dynamic "edge_ttl" {
-            for_each = action_parameters.value.edge_ttl != null ? [action_parameters.value.edge_ttl] : []
-            content {
-              mode    = edge_ttl.value.mode
-              default = edge_ttl.value.default_ttl > 0 ? edge_ttl.value.default_ttl : null
-
-              dynamic "status_code_ttl" {
-                for_each = edge_ttl.value.status_code_ttls
-                content {
-                  value       = status_code_ttl.value.value
-                  status_code = status_code_ttl.value.status_code > 0 ? status_code_ttl.value.status_code : null
-
-                  dynamic "status_code_range" {
-                    for_each = status_code_ttl.value.status_code_range != null ? [status_code_ttl.value.status_code_range] : []
-                    content {
-                      from = status_code_range.value.from
-                      to   = status_code_range.value.to
-                    }
-                  }
-                }
-              }
-            }
-          }
-
-          dynamic "browser_ttl" {
-            for_each = action_parameters.value.browser_ttl != null ? [action_parameters.value.browser_ttl] : []
-            content {
-              mode    = browser_ttl.value.mode
-              default = browser_ttl.value.default_ttl > 0 ? browser_ttl.value.default_ttl : null
-            }
-          }
-
-          dynamic "serve_stale" {
-            for_each = action_parameters.value.serve_stale != null ? [action_parameters.value.serve_stale] : []
-            content {
-              disable_stale_while_updating = serve_stale.value.disable_stale_while_updating
-            }
-          }
+        serve_stale = r.action_parameters.serve_stale == null ? null : {
+          disable_stale_while_updating = r.action_parameters.serve_stale.disable_stale_while_updating
         }
       }
     }
-  }
+  ]
 }

--- a/apis/org/openmcf/provider/cloudflare/cloudflareruleset/v1/iac/tf/provider.tf
+++ b/apis/org/openmcf/provider/cloudflare/cloudflareruleset/v1/iac/tf/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/apis/org/openmcf/provider/cloudflare/cloudflareruleset/v1/iac/tf/variables.tf
+++ b/apis/org/openmcf/provider/cloudflare/cloudflareruleset/v1/iac/tf/variables.tf
@@ -14,10 +14,8 @@ variable "metadata" {
 variable "spec" {
   description = "CloudflareRulesetSpec defines the configuration for a Cloudflare Ruleset"
   type = object({
-    # Cloudflare Zone ID (StringValueOrRef — use value for literal)
-    zone_id = optional(object({
-      value = string
-    }))
+    # Cloudflare Zone ID (StringValueOrRef flattened to a plain string by the tfvars converter)
+    zone_id = optional(string)
 
     # Cloudflare Account ID (for account-level rulesets)
     account_id = optional(string, "")

--- a/apis/org/openmcf/provider/cloudflare/cloudflareworker/v1/docs/README.md
+++ b/apis/org/openmcf/provider/cloudflare/cloudflareworker/v1/docs/README.md
@@ -161,26 +161,30 @@ Terraform's official `cloudflare/cloudflare` provider is automatically generated
 **Example:**
 
 ```hcl
-resource "cloudflare_worker_script" "api" {
-  account_id = var.cloudflare_account_id
-  name       = "api-gateway"
-  content    = file("./dist/worker.js")
-  
-  kv_namespace_binding {
-    name         = "CACHE"
-    namespace_id = cloudflare_workers_kv_namespace.cache.id
-  }
-  
-  plain_text_binding {
-    name = "ENVIRONMENT"
-    text = "production"
-  }
+resource "cloudflare_workers_script" "api" {
+  account_id  = var.cloudflare_account_id
+  script_name = "api-gateway"
+  content     = file("./dist/worker.js")
+  main_module = "index.js"
+
+  bindings = [
+    {
+      name         = "CACHE"
+      type         = "kv_namespace"
+      namespace_id = cloudflare_workers_kv_namespace.cache.id
+    },
+    {
+      name = "ENVIRONMENT"
+      type = "plain_text"
+      text = "production"
+    }
+  ]
 }
 
-resource "cloudflare_worker_route" "api_route" {
-  zone_id     = var.cloudflare_zone_id
-  pattern     = "api.example.com/*"
-  script_name = cloudflare_worker_script.api.name
+resource "cloudflare_workers_route" "api_route" {
+  zone_id = var.cloudflare_zone_id
+  pattern = "api.example.com/*"
+  script  = cloudflare_workers_script.api.script_name
 }
 ```
 

--- a/apis/org/openmcf/provider/cloudflare/cloudflareworker/v1/iac/hack/manifest.yaml
+++ b/apis/org/openmcf/provider/cloudflare/cloudflareworker/v1/iac/hack/manifest.yaml
@@ -3,11 +3,12 @@ kind: CloudflareWorker
 metadata:
   name: test-worker
 spec:
-  account_id: "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6"
-  script:
-    name: test-worker
-    bundle:
-      bucket: test-workers-bucket
-      path: builds/test-worker-v1.0.0.js
-  compatibility_date: "2025-01-15"
-
+  accountId: "0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d"
+  workerName: test-worker
+  scriptBundle:
+    bucket: openmcf-workers
+    path: builds/test-worker-v1.0.0.js
+  compatibilityDate: "2025-01-15"
+  env:
+    variables:
+      LOG_LEVEL: info

--- a/apis/org/openmcf/provider/cloudflare/cloudflareworker/v1/iac/pulumi/module/dns_record.go
+++ b/apis/org/openmcf/provider/cloudflare/cloudflareworker/v1/iac/pulumi/module/dns_record.go
@@ -13,7 +13,7 @@ func createDnsRecord(
 	locals *Locals,
 	cloudflareProvider *cloudfl.Provider,
 	zoneId pulumi.StringOutput,
-) (*cloudfl.Record, error) {
+) (*cloudfl.DnsRecord, error) {
 
 	// Check if DNS configuration is provided and enabled
 	if locals.CloudflareWorker.Spec.Dns == nil || !locals.CloudflareWorker.Spec.Dns.Enabled {
@@ -28,20 +28,19 @@ func createDnsRecord(
 		return nil, errors.New("dns.hostname is required when dns is enabled")
 	}
 
-	// Create A record with a dummy IP (100.0.0.1)
-	// The IP doesn't matter because the Worker will handle all requests at the edge
-	// The key is that the record must be proxied (orange cloud) so traffic hits Cloudflare
-	recordArgs := &cloudfl.RecordArgs{
+	// Create an AAAA record pointed at a dummy address. The address is never used
+	// because the record is proxied (orange cloud) and the Worker handles all
+	// requests at the edge.
+	recordArgs := &cloudfl.DnsRecordArgs{
 		ZoneId:  zoneId.ToStringOutput(),
 		Name:    pulumi.String(dns.Hostname),
-		Type:    pulumi.String("A"),
-		Content: pulumi.String("100.0.0.1"), // Dummy IP - not used due to proxying
-		Proxied: pulumi.Bool(true),          // Orange cloud - routes through Cloudflare
-		Comment: pulumi.String("Managed by Planton - Routes to Cloudflare Worker"),
-		Ttl:     pulumi.Float64(1), // TTL is automatic when proxied
+		Type:    pulumi.String("AAAA"),
+		Content: pulumi.String("100::"), // Dummy IPv6 - not used due to proxying
+		Proxied: pulumi.Bool(true),      // Orange cloud - routes through Cloudflare
+		Ttl:     pulumi.Float64(1),      // TTL is automatic when proxied
 	}
 
-	createdRecord, err := cloudfl.NewRecord(
+	createdRecord, err := cloudfl.NewDnsRecord(
 		ctx,
 		"dns-record",
 		recordArgs,

--- a/apis/org/openmcf/provider/cloudflare/cloudflareworker/v1/iac/pulumi/module/worker_script.go
+++ b/apis/org/openmcf/provider/cloudflare/cloudflareworker/v1/iac/pulumi/module/worker_script.go
@@ -44,6 +44,14 @@ func createWorkerScript(
 				Text: pulumi.String(v),
 			})
 		}
+		// Secret environment variables become secret_text bindings (stored encrypted).
+		for k, v := range locals.CloudflareWorker.Spec.Env.Secrets {
+			bindings = append(bindings, cloudfl.WorkersScriptBindingArgs{
+				Name: pulumi.String(k),
+				Type: pulumi.String("secret_text"),
+				Text: pulumi.String(v),
+			})
+		}
 	}
 
 	// Add KV namespace bindings

--- a/apis/org/openmcf/provider/cloudflare/cloudflareworker/v1/iac/tf/README.md
+++ b/apis/org/openmcf/provider/cloudflare/cloudflareworker/v1/iac/tf/README.md
@@ -90,7 +90,7 @@ terraform {
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
     aws = {
       source  = "hashicorp/aws"
@@ -172,8 +172,8 @@ terraform apply
 Plan: 3 to add, 0 to change, 0 to destroy.
 
   + cloudflare_workers_script.main
-  + cloudflare_record.worker_dns[0]
-  + cloudflare_worker_route.main[0]
+  + cloudflare_dns_record.worker_dns[0]
+  + cloudflare_workers_route.main[0]
 
 Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
 

--- a/apis/org/openmcf/provider/cloudflare/cloudflareworker/v1/iac/tf/locals.tf
+++ b/apis/org/openmcf/provider/cloudflare/cloudflareworker/v1/iac/tf/locals.tf
@@ -1,7 +1,7 @@
 locals {
   # Resource naming
   resource_name = coalesce(try(var.metadata.name, null), "cloudflare-worker")
-  
+
   # Labels/tags
   labels = merge({
     "name" = local.resource_name
@@ -9,7 +9,7 @@ locals {
 
   # Worker script configuration
   script_name = var.spec.worker_name
-  
+
   # R2 bundle configuration
   r2_bucket = var.spec.script_bundle.bucket
   r2_path   = var.spec.script_bundle.path
@@ -18,26 +18,19 @@ locals {
   kv_bindings = try(var.spec.kv_bindings, [])
 
   # DNS configuration
-  dns_enabled = try(var.spec.dns.enabled, false)
-  dns_zone_id = try(var.spec.dns.zone_id.value, "")
+  dns_enabled  = try(var.spec.dns.enabled, false)
+  dns_zone_id  = try(var.spec.dns.zone_id, "")
   dns_hostname = try(var.spec.dns.hostname, "")
-  
+
   # Route pattern (defaults to hostname/* if not specified)
   route_pattern = try(var.spec.dns.route_pattern, "") != "" ? var.spec.dns.route_pattern : "${local.dns_hostname}/*"
 
   # Compatibility date (defaults to today if not specified)
   compatibility_date = try(var.spec.compatibility_date, "") != "" ? var.spec.compatibility_date : formatdate("YYYY-MM-DD", timestamp())
 
-  # Usage model mapping
-  usage_model_map = {
-    0 = "bundled"
-    1 = "unbound"
-  }
-  usage_model = lookup(local.usage_model_map, try(var.spec.usage_model, 0), "bundled")
-
   # Environment variables
   env_variables = try(var.spec.env.variables, {})
-  
+
   # Secrets (note: Terraform doesn't support direct secret upload via Workers API)
   env_secrets = try(var.spec.env.secrets, {})
 }

--- a/apis/org/openmcf/provider/cloudflare/cloudflareworker/v1/iac/tf/main.tf
+++ b/apis/org/openmcf/provider/cloudflare/cloudflareworker/v1/iac/tf/main.tf
@@ -8,72 +8,70 @@ data "aws_s3_object" "worker_bundle" {
 
 # Cloudflare Worker Script
 resource "cloudflare_workers_script" "main" {
-  account_id = var.spec.account_id
-  name       = local.script_name
+  account_id  = var.spec.account_id
+  script_name = local.script_name
 
   # Worker content from R2 bundle
   content = data.aws_s3_object.worker_bundle.body
 
-  # Module format (as opposed to service worker format)
-  module = true
+  # Module-format worker (the entrypoint is an ES module).
+  main_module = "index.js"
 
   # Compatibility settings
   compatibility_date  = local.compatibility_date
   compatibility_flags = ["nodejs_compat"]
 
-  # Plain text bindings (environment variables)
-  dynamic "plain_text_binding" {
-    for_each = local.env_variables
-    content {
-      name = plain_text_binding.key
-      text = plain_text_binding.value
-    }
-  }
+  # Flat bindings list. Each element carries the full attribute set; unused
+  # attributes are null so all elements share one object type.
+  bindings = concat(
+    [for k, v in local.env_variables : {
+      name         = k
+      type         = "plain_text"
+      text         = v
+      namespace_id = null
+    }],
+    [for b in local.kv_bindings : {
+      name         = b.name
+      type         = "kv_namespace"
+      text         = null
+      namespace_id = b.field_path
+    }],
+    [for k, v in local.env_secrets : {
+      name         = k
+      type         = "secret_text"
+      text         = v
+      namespace_id = null
+    }],
+  )
 
-  # KV namespace bindings
-  dynamic "kv_namespace_binding" {
-    for_each = local.kv_bindings
-    content {
-      name         = kv_namespace_binding.value.name
-      namespace_id = kv_namespace_binding.value.field_path
-    }
+  # Enable Workers Logs for observability.
+  observability = {
+    enabled            = true
+    head_sampling_rate = 1
   }
-
-  # Secret bindings
-  # Note: Terraform doesn't support uploading secrets directly
-  # Secrets must be managed separately via Cloudflare API or dashboard
-  dynamic "secret_text_binding" {
-    for_each = local.env_secrets
-    content {
-      name = secret_text_binding.key
-      text = secret_text_binding.value
-    }
-  }
-
-  # Enable observability (logs)
-  logpush = true
 }
 
 # DNS Record for custom domain (if DNS is enabled)
-resource "cloudflare_record" "worker_dns" {
+resource "cloudflare_dns_record" "worker_dns" {
   count = local.dns_enabled ? 1 : 0
 
   zone_id = local.dns_zone_id
   name    = local.dns_hostname
   type    = "AAAA"
-  value   = "100::"  # Dummy IPv6 address for Workers routes
-  proxied = true      # Orange cloud - required for Workers
+  content = "100::" # Dummy IPv6 address; the proxied Worker handles requests at the edge
+  ttl     = 1
+  proxied = true # Orange cloud - required for Workers
 }
 
 # Worker Route (if DNS is enabled)
-resource "cloudflare_worker_route" "main" {
+resource "cloudflare_workers_route" "main" {
   count = local.dns_enabled ? 1 : 0
 
-  zone_id     = local.dns_zone_id
-  pattern     = local.route_pattern
-  script_name = cloudflare_workers_script.main.name
+  zone_id = local.dns_zone_id
+  pattern = local.route_pattern
+  script  = cloudflare_workers_script.main.script_name
 
   # Ensure DNS record exists before creating route
-  depends_on = [cloudflare_record.worker_dns]
+  depends_on = [cloudflare_dns_record.worker_dns]
 }
 

--- a/apis/org/openmcf/provider/cloudflare/cloudflareworker/v1/iac/tf/outputs.tf
+++ b/apis/org/openmcf/provider/cloudflare/cloudflareworker/v1/iac/tf/outputs.tf
@@ -3,20 +3,10 @@ output "script_id" {
   value       = cloudflare_workers_script.main.id
 }
 
-output "script_name" {
-  description = "The name of the Worker script"
-  value       = cloudflare_workers_script.main.name
-}
-
 output "route_urls" {
   description = "List of route URLs where the Worker is accessible"
   value = local.dns_enabled ? [
     "https://${local.dns_hostname}"
   ] : []
-}
-
-output "route_pattern" {
-  description = "The route pattern for the Worker"
-  value       = local.dns_enabled ? local.route_pattern : ""
 }
 

--- a/apis/org/openmcf/provider/cloudflare/cloudflareworker/v1/iac/tf/provider.tf
+++ b/apis/org/openmcf/provider/cloudflare/cloudflareworker/v1/iac/tf/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/apis/org/openmcf/provider/cloudflare/cloudflareworker/v1/iac/tf/variables.tf
+++ b/apis/org/openmcf/provider/cloudflare/cloudflareworker/v1/iac/tf/variables.tf
@@ -22,22 +22,20 @@ variable "spec" {
 
     # Worker script bundle configuration (R2 object reference)
     script_bundle = object({
-      bucket = string  # R2 bucket name
-      path   = string  # Path to bundle in R2
+      bucket = string # R2 bucket name
+      path   = string # Path to bundle in R2
     })
 
     # Optional KV namespace bindings
     kv_bindings = optional(list(object({
       name       = string
-      field_path = string  # Namespace ID reference
+      field_path = string # Namespace ID reference
     })), [])
 
     # Optional DNS configuration for custom domain
     dns = optional(object({
-      enabled = optional(bool, false)
-      zone_id = optional(object({
-        value = optional(string, "")
-      }))
+      enabled       = optional(bool, false)
+      zone_id       = optional(string)
       hostname      = optional(string, "")
       route_pattern = optional(string, "")
     }))
@@ -45,8 +43,8 @@ variable "spec" {
     # Compatibility date (YYYY-MM-DD format)
     compatibility_date = optional(string, "")
 
-    # Usage model: 0=BUNDLED, 1=UNBOUND
-    usage_model = optional(number, 0)
+    # Usage model ("standard"/"bundled"/"unbound"); enum flattens to its string name.
+    usage_model = optional(string)
 
     # Environment variables and secrets
     env = optional(object({

--- a/apis/org/openmcf/provider/cloudflare/cloudflarezerotrustaccessapplication/v1/catalog-page.md
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarezerotrustaccessapplication/v1/catalog-page.md
@@ -6,8 +6,8 @@ Deploys a Cloudflare Zero Trust Access Application that protects a hostname behi
 
 When you deploy a CloudflareZeroTrustAccessApplication resource, OpenMCF provisions:
 
-- **Access Application** — a `cloudflare_access_application` of type `self_hosted`, bound to the specified DNS zone and hostname, with an optional custom session duration
-- **Access Policy** — a `cloudflare_access_policy` attached to the application with an `allow` or `deny` decision, email-based include rules, optional Google Workspace group includes, and an optional MFA requirement
+- **Access Application** — a `cloudflare_zero_trust_access_application` of type `self_hosted`, bound to the specified DNS zone and hostname, with an optional custom session duration
+- **Access Policy** — a `cloudflare_zero_trust_access_policy` attached to the application with an `allow` or `deny` decision, email-based include rules, optional Google Workspace group includes, and an optional MFA requirement
 
 ## Prerequisites
 

--- a/apis/org/openmcf/provider/cloudflare/cloudflarezerotrustaccessapplication/v1/docs/README.md
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarezerotrustaccessapplication/v1/docs/README.md
@@ -80,27 +80,26 @@ Not all approaches to configuring Cloudflare Access are created equal. Here's th
 **Terraform example:**
 
 ```hcl
+resource "cloudflare_zero_trust_access_policy" "allow_employees" {
+  account_id = var.cloudflare_account_id
+  name       = "Allow employees with MFA"
+  decision   = "allow"
+
+  include = [{ email_domain = { domain = "example.com" } }]
+  require = [{ auth_method = { auth_method = "mfa" } }]
+}
+
 resource "cloudflare_zero_trust_access_application" "internal_dashboard" {
   account_id       = var.cloudflare_account_id
   name             = "Internal Dashboard"
   domain           = "dash.example.com"
   type             = "self_hosted"
   session_duration = "8h"
-}
 
-resource "cloudflare_access_policy" "allow_employees" {
-  application_id = cloudflare_zero_trust_access_application.internal_dashboard.id
-  name           = "Allow employees with MFA"
-  decision       = "allow"
-  precedence     = 1
-
-  include {
-    email_domain = ["example.com"]
-  }
-
-  require {
-    auth_method = ["mfa"]
-  }
+  policies = [{
+    id         = cloudflare_zero_trust_access_policy.allow_employees.id
+    precedence = 1
+  }]
 }
 ```
 
@@ -109,20 +108,20 @@ resource "cloudflare_access_policy" "allow_employees" {
 ```python
 import pulumi_cloudflare as cloudflare
 
+policy = cloudflare.ZeroTrustAccessPolicy("allow-employees",
+    account_id=account_id,
+    name="Allow employees with MFA",
+    decision="allow",
+    includes=[{"email_domain": {"domain": "example.com"}}],
+    requires=[{"auth_method": {"auth_method": "mfa"}}])
+
 app = cloudflare.ZeroTrustAccessApplication("internal-dashboard",
     account_id=account_id,
     name="Internal Dashboard",
     domain="dash.example.com",
     type="self_hosted",
-    session_duration="8h")
-
-policy = cloudflare.AccessPolicy("allow-employees",
-    application_id=app.id,
-    name="Allow employees with MFA",
-    decision="allow",
-    precedence=1,
-    includes=[{"email_domain": ["example.com"]}],
-    requires=[{"auth_method": ["mfa"]}])
+    session_duration="8h",
+    policies=[{"id": policy.id, "precedence": 1}])
 ```
 
 **What it solves:** Everything. You get:
@@ -158,7 +157,7 @@ Both tools cover Cloudflare Access comprehensively. The choice comes down to pre
 - Cloudflare's docs often reference Terraform examples directly
 
 **Considerations:**
-- Recent provider updates renamed resources (e.g., `cloudflare_access_application` → `cloudflare_zero_trust_access_application`). Upgrading requires migration.
+- Access resources are named `cloudflare_zero_trust_access_application` and `cloudflare_zero_trust_access_policy`; a policy is a standalone account-scoped object that an application references through its `policies` list.
 - Edge cases like policy rule logic (AND vs. OR) can be tricky to express in HCL, requiring careful reading of docs.
 
 ### Pulumi: The Programmable Alternative

--- a/apis/org/openmcf/provider/cloudflare/cloudflarezerotrustaccessapplication/v1/hack/manifest.yaml
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarezerotrustaccessapplication/v1/hack/manifest.yaml
@@ -1,5 +1,17 @@
 apiVersion: cloudflare.openmcf.org/v1
 kind: CloudflareZeroTrustAccessApplication
 metadata:
-  name: first-certificate
+  name: access-app-hack
 spec:
+  applicationName: Internal Dashboard
+  zoneId:
+    value: "0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d"
+  hostname: dashboard.openmcf-example.com
+  policyType: ALLOW
+  allowedEmails:
+    - alice@example.com
+    - bob@example.com
+  allowedGoogleGroups:
+    - "1234567890abcdef1234567890abcdef"
+  sessionDurationMinutes: 1440
+  requireMfa: true

--- a/apis/org/openmcf/provider/cloudflare/cloudflarezerotrustaccessapplication/v1/iac/pulumi/README.md
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarezerotrustaccessapplication/v1/iac/pulumi/README.md
@@ -185,18 +185,19 @@ pulumi stack output policy_id
 
 The `application.go` module creates:
 
-1. **Access Application** (`cloudflare.NewAccessApplication`):
+1. **Zone Lookup** (`cloudflare.LookupZone`):
+   - Looks up the Cloudflare zone to retrieve the account ID (required for the account-scoped policy and application)
+
+2. **Access Policy** (`cloudflare.NewZeroTrustAccessPolicy`):
+   - Creates a standalone, account-scoped policy with decision type (allow or deny)
+   - Adds Include rules for allowed emails and Google groups
+   - Adds Require rules for MFA enforcement (if enabled)
+
+3. **Access Application** (`cloudflare.NewZeroTrustAccessApplication`):
    - Sets application name and hostname
    - Configures session duration (converted from minutes to duration string, e.g., "480m")
    - Sets type to "self_hosted"
-
-2. **Zone Lookup** (`cloudflare.LookupZone`):
-   - Looks up the Cloudflare zone to retrieve the account ID (required for Access Policy)
-
-3. **Access Policy** (`cloudflare.NewAccessPolicy`):
-   - Creates policy with decision type (allow or deny)
-   - Adds Include rules for allowed emails and Google groups
-   - Adds Require rules for MFA enforcement (if enabled)
+   - References the policy through its `policies` list
 
 ### Policy Logic
 

--- a/apis/org/openmcf/provider/cloudflare/cloudflarezerotrustaccessapplication/v1/iac/pulumi/module/application.go
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarezerotrustaccessapplication/v1/iac/pulumi/module/application.go
@@ -9,112 +9,111 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-// application provisions the Access Application and its default policy.
+// application provisions the Access Policy and the Access Application that
+// references it. In v5 a policy is a standalone, account-scoped object; the
+// application links it through its policies list.
 func application(
 	ctx *pulumi.Context,
 	locals *Locals,
 	cloudflareProvider *cloudflare.Provider,
-) (*cloudflare.AccessApplication, error) {
+) (*cloudflare.ZeroTrustAccessApplication, error) {
 
-	// --- Access Application --------------------------------------------------
+	spec := locals.CloudflareZeroTrustAccessApplication.Spec
+
 	// Resolve zone_id from literal value or reference.
 	zoneId := ""
-	if locals.CloudflareZeroTrustAccessApplication.Spec.ZoneId != nil {
-		zoneId = locals.CloudflareZeroTrustAccessApplication.Spec.ZoneId.GetValue()
+	if spec.ZoneId != nil {
+		zoneId = spec.ZoneId.GetValue()
 	}
 	if zoneId == "" {
 		return nil, errors.New("zone_id is required")
 	}
 
-	appArgs := &cloudflare.AccessApplicationArgs{
-		Name:   pulumi.String(locals.CloudflareZeroTrustAccessApplication.Spec.ApplicationName),
-		ZoneId: pulumi.String(zoneId),
-		Domain: pulumi.String(locals.CloudflareZeroTrustAccessApplication.Spec.Hostname),
-		Type:   pulumi.StringPtr("self_hosted"),
-	}
-
-	if locals.CloudflareZeroTrustAccessApplication.Spec.SessionDurationMinutes > 0 {
-		appArgs.SessionDuration = pulumi.StringPtr(
-			fmt.Sprintf("%dm", locals.CloudflareZeroTrustAccessApplication.Spec.SessionDurationMinutes),
-		)
-	}
-
-	createdAccessApplication, err := cloudflare.NewAccessApplication(
-		ctx,
-		"access_application",
-		appArgs,
-		pulumi.Provider(cloudflareProvider),
-	)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create access application")
-	}
-
-	// --- Access Policy -------------------------------------------------------
-	// Lookup zone to get account ID (required for AccessPolicy in v6)
+	// Lookup zone to get account ID (required for account-scoped resources).
 	zone := cloudflare.LookupZoneOutput(ctx, cloudflare.LookupZoneOutputArgs{
 		ZoneId: pulumi.String(zoneId),
 	}, pulumi.Provider(cloudflareProvider))
-
 	accountId := zone.Account().Id()
 
-	var includeBlocks cloudflare.AccessPolicyIncludeArray
-	// In v6, email and group are nested structures, not arrays
-	// Each email/group needs to be a separate include block
-	if len(locals.CloudflareZeroTrustAccessApplication.Spec.AllowedEmails) > 0 {
-		for _, e := range locals.CloudflareZeroTrustAccessApplication.Spec.AllowedEmails {
-			includeBlocks = append(includeBlocks, &cloudflare.AccessPolicyIncludeArgs{
-				Email: &cloudflare.AccessPolicyIncludeEmailArgs{
-					Email: pulumi.String(e),
-				},
-			})
-		}
+	// --- Access Policy -------------------------------------------------------
+	var includes cloudflare.ZeroTrustAccessPolicyIncludeArray
+	for _, e := range spec.AllowedEmails {
+		includes = append(includes, &cloudflare.ZeroTrustAccessPolicyIncludeArgs{
+			Email: &cloudflare.ZeroTrustAccessPolicyIncludeEmailArgs{
+				Email: pulumi.String(e),
+			},
+		})
+	}
+	for _, g := range spec.AllowedGoogleGroups {
+		includes = append(includes, &cloudflare.ZeroTrustAccessPolicyIncludeArgs{
+			Group: &cloudflare.ZeroTrustAccessPolicyIncludeGroupArgs{
+				Id: pulumi.String(g),
+			},
+		})
 	}
 
-	if len(locals.CloudflareZeroTrustAccessApplication.Spec.AllowedGoogleGroups) > 0 {
-		for _, g := range locals.CloudflareZeroTrustAccessApplication.Spec.AllowedGoogleGroups {
-			includeBlocks = append(includeBlocks, &cloudflare.AccessPolicyIncludeArgs{
-				Group: &cloudflare.AccessPolicyIncludeGroupArgs{
-					Id: pulumi.String(g),
-				},
-			})
-		}
-	}
-
-	var requireBlocks cloudflare.AccessPolicyRequireArray
-	if locals.CloudflareZeroTrustAccessApplication.Spec.RequireMfa {
-		requireBlocks = append(requireBlocks, &cloudflare.AccessPolicyRequireArgs{
-			AuthMethod: &cloudflare.AccessPolicyRequireAuthMethodArgs{
+	var requires cloudflare.ZeroTrustAccessPolicyRequireArray
+	if spec.RequireMfa {
+		requires = append(requires, &cloudflare.ZeroTrustAccessPolicyRequireArgs{
+			AuthMethod: &cloudflare.ZeroTrustAccessPolicyRequireAuthMethodArgs{
 				AuthMethod: pulumi.String("mfa"),
 			},
 		})
 	}
 
 	decision := "allow"
-	if locals.CloudflareZeroTrustAccessApplication.Spec.PolicyType ==
-		cloudflarezerotrustaccessapplicationv1.CloudflareZeroTrustPolicyType_BLOCK {
+	if spec.PolicyType == cloudflarezerotrustaccessapplicationv1.CloudflareZeroTrustPolicyType_BLOCK {
 		decision = "deny"
 	}
 
-	createdAccessPolicy, err := cloudflare.NewAccessPolicy(
+	createdAccessPolicy, err := cloudflare.NewZeroTrustAccessPolicy(
 		ctx,
 		"access_policy",
-		&cloudflare.AccessPolicyArgs{
+		&cloudflare.ZeroTrustAccessPolicyArgs{
 			AccountId: accountId,
 			Name:      pulumi.String("default-policy"),
 			Decision:  pulumi.String(decision),
-			Includes:  includeBlocks,
-			Requires:  requireBlocks,
+			Includes:  includes,
+			Requires:  requires,
 		},
 		pulumi.Provider(cloudflareProvider),
-		pulumi.DependsOn([]pulumi.Resource{createdAccessApplication}),
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create access policy")
 	}
 
+	// --- Access Application --------------------------------------------------
+	appArgs := &cloudflare.ZeroTrustAccessApplicationArgs{
+		AccountId: accountId,
+		Name:      pulumi.String(spec.ApplicationName),
+		Domain:    pulumi.String(spec.Hostname),
+		Type:      pulumi.StringPtr("self_hosted"),
+		Policies: cloudflare.ZeroTrustAccessApplicationPolicyArray{
+			&cloudflare.ZeroTrustAccessApplicationPolicyArgs{
+				Id:         createdAccessPolicy.ID(),
+				Precedence: pulumi.IntPtr(1),
+			},
+		},
+	}
+
+	if spec.SessionDurationMinutes > 0 {
+		appArgs.SessionDuration = pulumi.StringPtr(fmt.Sprintf("%dm", spec.SessionDurationMinutes))
+	}
+
+	createdAccessApplication, err := cloudflare.NewZeroTrustAccessApplication(
+		ctx,
+		"access_application",
+		appArgs,
+		pulumi.Provider(cloudflareProvider),
+		pulumi.DependsOn([]pulumi.Resource{createdAccessPolicy}),
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create access application")
+	}
+
 	// --- Stack Outputs -------------------------------------------------------
 	ctx.Export(OpApplicationId, createdAccessApplication.ID())
-	ctx.Export(OpPublicHostname, pulumi.String(locals.CloudflareZeroTrustAccessApplication.Spec.Hostname))
+	ctx.Export(OpPublicHostname, pulumi.String(spec.Hostname))
 	ctx.Export(OpPolicyId, createdAccessPolicy.ID())
 
 	return createdAccessApplication, nil

--- a/apis/org/openmcf/provider/cloudflare/cloudflarezerotrustaccessapplication/v1/iac/tf/README.md
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarezerotrustaccessapplication/v1/iac/tf/README.md
@@ -219,74 +219,47 @@ The `main.tf` file contains the core resource definitions:
    ```
    Looks up the zone to retrieve the account ID (required for Access Policy).
 
-2. **Resource: Access Application**
+2. **Resource: Access Policy**
    ```hcl
-   resource "cloudflare_access_application" "main" {
-     account_id       = data.cloudflare_zone.main.account_id
+   resource "cloudflare_zero_trust_access_policy" "main" {
+     account_id = data.cloudflare_zone.main.account.id
+     name       = "default-policy"
+     decision   = var.spec.policy_type == "BLOCK" ? "deny" : "allow"
+
+     include = concat(
+       [for e in var.spec.allowed_emails : { email = { email = e }, group = null }],
+       [for g in var.spec.allowed_google_groups : { email = null, group = { id = g } }],
+     )
+     require = var.spec.require_mfa ? [{ auth_method = { auth_method = "mfa" } }] : []
+   }
+   ```
+   A policy is a standalone, account-scoped object with Include (who can access) and Require (MFA) rules.
+
+3. **Resource: Access Application**
+   ```hcl
+   resource "cloudflare_zero_trust_access_application" "main" {
+     account_id       = data.cloudflare_zone.main.account.id
      name             = var.spec.application_name
      domain           = var.spec.hostname
      type             = "self_hosted"
      session_duration = var.spec.session_duration_minutes > 0 ? "${var.spec.session_duration_minutes}m" : "24h"
+
+     policies = [{
+       id         = cloudflare_zero_trust_access_policy.main.id
+       precedence = 1
+     }]
    }
    ```
-   Creates the Access Application with hostname and session configuration.
+   The application references the policy through its `policies` list (precedence sets evaluation order).
 
-3. **Resource: Access Policy**
-   ```hcl
-   resource "cloudflare_access_policy" "main" {
-     account_id     = data.cloudflare_zone.main.account_id
-     application_id = cloudflare_access_application.main.id
-     name           = "default-policy"
-     decision       = var.spec.policy_type == "BLOCK" ? "deny" : "allow"
-     
-     # Dynamic Include blocks for emails and groups
-     # Dynamic Require block for MFA
-   }
-   ```
-   Creates the policy with Include (who can access) and Require (MFA) rules.
+### Rule Construction
 
-### Dynamic Blocks
+Include and Require rules are built with attribute (object) syntax. Each include element carries the
+full attribute set (unused keys are `null`) so all elements share one object type:
 
-The implementation uses **dynamic blocks** to conditionally create Include and Require rules:
-
-#### Email Include Rules
-
-```hcl
-dynamic "include" {
-  for_each = var.spec.allowed_emails
-  content {
-    email = [include.value]
-  }
-}
-```
-
-Each email in `allowed_emails` creates a separate Include block.
-
-#### Group Include Rules
-
-```hcl
-dynamic "include" {
-  for_each = var.spec.allowed_google_groups
-  content {
-    group = [include.value]
-  }
-}
-```
-
-Each group in `allowed_google_groups` creates a separate Include block.
-
-#### MFA Require Rule
-
-```hcl
-dynamic "require" {
-  for_each = var.spec.require_mfa ? [1] : []
-  content {
-    auth_method = ["mfa"]
-  }
-}
-```
-
-If `require_mfa` is `true`, creates a Require block enforcing MFA.
+- Each email in `allowed_emails` becomes `{ email = { email = <value> } }`.
+- Each group in `allowed_google_groups` becomes `{ group = { id = <value> } }`.
+- When `require_mfa` is `true`, the require list contains `{ auth_method = { auth_method = "mfa" } }`.
 
 ## State Management
 
@@ -500,10 +473,10 @@ If you have existing Access Applications created via the dashboard, import them:
 
 ```bash
 # Import Access Application
-terraform import cloudflare_access_application.main <account_id>/<application_id>
+terraform import cloudflare_zero_trust_access_application.main <account_id>/<application_id>
 
 # Import Access Policy
-terraform import cloudflare_access_policy.main <account_id>/<policy_id>
+terraform import cloudflare_zero_trust_access_policy.main <account_id>/<policy_id>
 ```
 
 ## Debugging

--- a/apis/org/openmcf/provider/cloudflare/cloudflarezerotrustaccessapplication/v1/iac/tf/main.tf
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarezerotrustaccessapplication/v1/iac/tf/main.tf
@@ -1,51 +1,42 @@
 # main.tf
 
-# Lookup the Cloudflare zone to get account_id
+# Lookup the Cloudflare zone to get the account id (Access policies and
+# account-scoped applications require it).
 data "cloudflare_zone" "main" {
-  zone_id = var.spec.zone_id.value
+  zone_id = var.spec.zone_id
 }
 
-# Create the Cloudflare Zero Trust Access Application
-resource "cloudflare_access_application" "main" {
-  account_id = data.cloudflare_zone.main.account_id
+# Create the Access Policy. In v5 a policy is a standalone, account-scoped
+# object; the application references it via its policies list.
+resource "cloudflare_zero_trust_access_policy" "main" {
+  account_id = data.cloudflare_zone.main.account.id
+  name       = "default-policy"
+  decision   = var.spec.policy_type == "BLOCK" ? "deny" : "allow"
+
+  # Include rules. Each element carries the full attribute set (unused keys are
+  # null) so all elements share one object type.
+  include = concat(
+    [for e in var.spec.allowed_emails : { email = { email = e }, group = null }],
+    [for g in var.spec.allowed_google_groups : { email = null, group = { id = g } }],
+  )
+
+  # Require MFA when requested.
+  require = var.spec.require_mfa ? [{ auth_method = { auth_method = "mfa" } }] : []
+}
+
+# Create the Cloudflare Zero Trust Access Application and attach the policy.
+resource "cloudflare_zero_trust_access_application" "main" {
+  account_id = data.cloudflare_zone.main.account.id
   name       = var.spec.application_name
   domain     = var.spec.hostname
   type       = "self_hosted"
 
-  # Set session duration if specified (convert minutes to duration string)
+  # Session duration as a duration string (defaults to 24h).
   session_duration = var.spec.session_duration_minutes > 0 ? "${var.spec.session_duration_minutes}m" : "24h"
+
+  # Reference the policy; precedence is the evaluation order.
+  policies = [{
+    id         = cloudflare_zero_trust_access_policy.main.id
+    precedence = 1
+  }]
 }
-
-# Create the Access Policy for the application
-resource "cloudflare_access_policy" "main" {
-  account_id     = data.cloudflare_zone.main.account_id
-  application_id = cloudflare_access_application.main.id
-  name           = "default-policy"
-  precedence     = 1
-  decision       = var.spec.policy_type == "BLOCK" ? "deny" : "allow"
-
-  # Include rules for allowed emails
-  dynamic "include" {
-    for_each = var.spec.allowed_emails
-    content {
-      email = [include.value]
-    }
-  }
-
-  # Include rules for allowed Google groups
-  dynamic "include" {
-    for_each = var.spec.allowed_google_groups
-    content {
-      group = [include.value]
-    }
-  }
-
-  # Require MFA if specified
-  dynamic "require" {
-    for_each = var.spec.require_mfa ? [1] : []
-    content {
-      auth_method = ["mfa"]
-    }
-  }
-}
-

--- a/apis/org/openmcf/provider/cloudflare/cloudflarezerotrustaccessapplication/v1/iac/tf/outputs.tf
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarezerotrustaccessapplication/v1/iac/tf/outputs.tf
@@ -2,7 +2,7 @@
 
 output "application_id" {
   description = "The unique ID of the Cloudflare Access Application"
-  value       = cloudflare_access_application.main.id
+  value       = cloudflare_zero_trust_access_application.main.id
 }
 
 output "public_hostname" {
@@ -12,6 +12,6 @@ output "public_hostname" {
 
 output "policy_id" {
   description = "The ID of the Cloudflare Access policy associated with this application"
-  value       = cloudflare_access_policy.main.id
+  value       = cloudflare_zero_trust_access_policy.main.id
 }
 

--- a/apis/org/openmcf/provider/cloudflare/cloudflarezerotrustaccessapplication/v1/iac/tf/provider.tf
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarezerotrustaccessapplication/v1/iac/tf/provider.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/apis/org/openmcf/provider/cloudflare/cloudflarezerotrustaccessapplication/v1/iac/tf/variables.tf
+++ b/apis/org/openmcf/provider/cloudflare/cloudflarezerotrustaccessapplication/v1/iac/tf/variables.tf
@@ -16,10 +16,9 @@ variable "metadata" {
 variable "spec" {
   description = "CloudflareZeroTrustAccessApplicationSpec defines the configuration for the Access Application"
   type = object({
-    application_name         = string
-    zone_id = object({
-      value = string
-    })
+    application_name = string
+    # StringValueOrRef flattened to a plain string by the tfvars converter.
+    zone_id                  = optional(string)
     hostname                 = string
     policy_type              = optional(string, "ALLOW")
     allowed_emails           = optional(list(string), [])

--- a/pkg/outputs/conformance_test.go
+++ b/pkg/outputs/conformance_test.go
@@ -243,6 +243,18 @@ func TestStackOutputsConformance(t *testing.T) {
 			},
 			mustPopulate: []string{"ruleset_id", "version", "zone_id", "phase"},
 		},
+		{
+			// CloudflareLoadBalancer: both engines emit the load balancer id,
+			// hostname, and cname target as flat scalars onto the proto.
+			name: "CloudflareLoadBalancer",
+			kind: cloudresourcekind.CloudResourceKind_CloudflareLoadBalancer,
+			rawOutputs: map[string]interface{}{
+				"load_balancer_id":              "699d98642c564d2e855e9661899b7252",
+				"load_balancer_dns_record_name": "lb.example.com",
+				"load_balancer_cname_target":    "699d98642c564d2e855e9661899b7252",
+			},
+			mustPopulate: []string{"load_balancer_id", "load_balancer_dns_record_name", "load_balancer_cname_target"},
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/outputs/conformance_test.go
+++ b/pkg/outputs/conformance_test.go
@@ -230,6 +230,19 @@ func TestStackOutputsConformance(t *testing.T) {
 			},
 			mustPopulate: []string{"zone_id", "nameservers"},
 		},
+		{
+			// CloudflareRuleset: both engines emit ruleset id, version, and the
+			// zone_id/phase pass-throughs as flat scalars onto the proto.
+			name: "CloudflareRuleset",
+			kind: cloudresourcekind.CloudResourceKind_CloudflareRuleset,
+			rawOutputs: map[string]interface{}{
+				"ruleset_id": "2f2feab2026849078ba485f918791bdc",
+				"version":    "3",
+				"zone_id":    "023e105f4ecef8ad9ca31a8372d0c353",
+				"phase":      "http_request_origin",
+			},
+			mustPopulate: []string{"ruleset_id", "version", "zone_id", "phase"},
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/outputs/conformance_test.go
+++ b/pkg/outputs/conformance_test.go
@@ -206,6 +206,19 @@ func TestStackOutputsConformance(t *testing.T) {
 			},
 			mustPopulate: []string{"namespace_id"},
 		},
+		{
+			// CloudflareDnsRecord: both engines emit the record id, name, type and
+			// proxied flag as flat scalars onto the StackOutputs proto.
+			name: "CloudflareDnsRecord",
+			kind: cloudresourcekind.CloudResourceKind_CloudflareDnsRecord,
+			rawOutputs: map[string]interface{}{
+				"record_id":   "372e67954025e0ba6aaa6d586b9e0b59",
+				"hostname":    "www",
+				"record_type": "A",
+				"proxied":     true,
+			},
+			mustPopulate: []string{"record_id", "hostname", "record_type", "proxied"},
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/outputs/conformance_test.go
+++ b/pkg/outputs/conformance_test.go
@@ -184,6 +184,28 @@ func TestStackOutputsConformance(t *testing.T) {
 			},
 			mustPopulate: []string{"bucket_name", "bucket_url", "custom_domain_url"},
 		},
+		{
+			// CloudflareD1Database: both engines emit the database id and name as
+			// flat scalars; connection_string is emitted empty (no v5 attribute).
+			name: "CloudflareD1Database",
+			kind: cloudresourcekind.CloudResourceKind_CloudflareD1Database,
+			rawOutputs: map[string]interface{}{
+				"database_id":       "9a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d",
+				"database_name":     "app-prod-db",
+				"connection_string": "",
+			},
+			mustPopulate: []string{"database_id", "database_name"},
+		},
+		{
+			// CloudflareKvNamespace: both engines emit the namespace id as a flat
+			// scalar, which must land on the StackOutputs proto.
+			name: "CloudflareKvNamespace",
+			kind: cloudresourcekind.CloudResourceKind_CloudflareKvNamespace,
+			rawOutputs: map[string]interface{}{
+				"namespace_id": "0f1e2d3c4b5a69788796a5b4c3d2e1f0",
+			},
+			mustPopulate: []string{"namespace_id"},
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/outputs/conformance_test.go
+++ b/pkg/outputs/conformance_test.go
@@ -255,6 +255,17 @@ func TestStackOutputsConformance(t *testing.T) {
 			},
 			mustPopulate: []string{"load_balancer_id", "load_balancer_dns_record_name", "load_balancer_cname_target"},
 		},
+		{
+			// CloudflareWorker: both engines emit the script id (scalar) and the
+			// route urls (repeated string) onto the StackOutputs proto.
+			name: "CloudflareWorker",
+			kind: cloudresourcekind.CloudResourceKind_CloudflareWorker,
+			rawOutputs: map[string]interface{}{
+				"script_id":  "my-worker",
+				"route_urls": []interface{}{"https://app.example.com"},
+			},
+			mustPopulate: []string{"script_id", "route_urls"},
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/outputs/conformance_test.go
+++ b/pkg/outputs/conformance_test.go
@@ -266,6 +266,18 @@ func TestStackOutputsConformance(t *testing.T) {
 			},
 			mustPopulate: []string{"script_id", "route_urls"},
 		},
+		{
+			// CloudflareZeroTrustAccessApplication: both engines emit the
+			// application id, protected hostname, and policy id as flat scalars.
+			name: "CloudflareZeroTrustAccessApplication",
+			kind: cloudresourcekind.CloudResourceKind_CloudflareZeroTrustAccessApplication,
+			rawOutputs: map[string]interface{}{
+				"application_id":  "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+				"public_hostname": "dashboard.example.com",
+				"policy_id":       "699d98642c564d2e855e9661899b7252",
+			},
+			mustPopulate: []string{"application_id", "public_hostname", "policy_id"},
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/outputs/conformance_test.go
+++ b/pkg/outputs/conformance_test.go
@@ -219,6 +219,17 @@ func TestStackOutputsConformance(t *testing.T) {
 			},
 			mustPopulate: []string{"record_id", "hostname", "record_type", "proxied"},
 		},
+		{
+			// CloudflareDnsZone: both engines emit the zone id (scalar) and the
+			// assigned nameservers (repeated string) onto the StackOutputs proto.
+			name: "CloudflareDnsZone",
+			kind: cloudresourcekind.CloudResourceKind_CloudflareDnsZone,
+			rawOutputs: map[string]interface{}{
+				"zone_id":     "023e105f4ecef8ad9ca31a8372d0c353",
+				"nameservers": []interface{}{"ns1.cloudflare.com", "ns2.cloudflare.com"},
+			},
+			mustPopulate: []string{"zone_id", "nameservers"},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary

Completes the Cloudflare provider **v5** migration (`cloudflare ~> 5.0` / Pulumi `sdk/v6`) for the eight components that were still on v4 — `cloudflared1database`, `cloudflarekvnamespace`, `cloudflarednsrecord`, `cloudflarednszone`, `cloudflareruleset`, `cloudflareloadbalancer`, `cloudflareworker`, `cloudflarezerotrustaccessapplication`. With `CloudflareR2Bucket` already shipped (#445), **all nine Cloudflare kinds now deploy on provider v5** with Terraform↔Pulumi parity and proto-correct outputs.

One commit per component (`1d63f2c3c`..`67517e416`) plus a changelog.

## What changed

- Provider pinned to `~> 5.0`; v4 `dynamic` blocks rewritten to v5 attribute syntax (ruleset rules/action_parameters/headers-map, LB pool origins, D1 read_replication).
- Resource renames: `cloudflare_record`→`cloudflare_dns_record`, `cloudflare_worker_route`→`cloudflare_workers_route`, `cloudflare_access_*`→`cloudflare_zero_trust_access_*`; DNS zone nested `account = { id }`, removed `cloudflare_zone_settings_override`/`plan`/`jump_start`.
- Latent-bug fixes carried across the fleet: `StringValueOrRef` mistyped as `object({value})` → `optional(string)` (5 modules); enum-as-number → enum-name strings (LB `session_affinity`/`steering_policy`, worker `usage_model`); deprecated Pulumi `NewRecord`→`NewDnsRecord`; LB pool/monitor missing `AccountId`; orphaned zero-trust policy; dropped worker secrets.
- Per-kind cases added to `pkg/outputs/conformance_test.go` so engine output parity is CI-enforced for all nine kinds.

## Breaking changes

- **`CloudflareKvNamespaceSpec` gains a required `account_id`** — v5 requires it on `cloudflare_workers_kv_namespace` and KV has no zone to derive it from (mirrors R2/D1).
- Provider major bump to v5 for all Cloudflare kinds; v4-provider state needs migration.

## Test plan

- [x] `go test ./apis/org/openmcf/provider/cloudflare/...` (all nine green)
- [x] `go test ./pkg/outputs/` (conformance, all nine kinds)
- [x] `openmcf secret-coverage --check`
- [x] `go build` component + release-contract Pulumi entrypoints
- [x] `tofu validate` for all eight
- [x] real read-only `tofu plan` against a live account for D1, KV, DNS record, DNS zone, ruleset, load balancer, zero trust; worker `bindings` type-checked against the live v5 provider in isolation
- [ ] live `tofu apply`/`pulumi up` (optional full E2E; not run)