### PR TITLE
feat(cli): export the engine command registration seam for embedding hosts

### DIFF
--- a/cmd/planton/BUILD.bazel
+++ b/cmd/planton/BUILD.bazel
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cmd/planton/root",
-        "//internal/cli/flag",
         "@com_github_spf13_cobra//:cobra",
     ],
 )

--- a/cmd/planton/README.md
+++ b/cmd/planton/README.md
@@ -83,6 +83,39 @@ cmd/planton/
 
 ---
 
+## Embedding Contract
+
+The engine command set is exported through a single seam in `cmd/planton/root`:
+
+```go
+root.RegisterCommands(parent *cobra.Command, opts root.Options)
+```
+
+The standalone `planton` binary and any host binary that embeds the engine as a
+Go module (such as the Planton Platform CLI) both register commands through this
+function, so the two surfaces cannot drift. The seam:
+
+- registers every user-facing engine command (`apply`, `plan`, `destroy`,
+  `refresh`, `init`, `pulumi`, `tofu`, `terraform`, `kustomize`,
+  `load-manifest`, `validate-manifest`, `validate-refs`, `validate-outputs`,
+  `secret-coverage`, `checkout`, `pull`, `modules-version`);
+- registers the persistent flags those commands resolve through cobra flag
+  inheritance (`--local-module`, `--planton-git-repo`);
+- accepts `Options.ModulesVersion` so a host can pin module artifact downloads
+  to the engine version it compiled against (the standalone binary is stamped
+  via ldflags instead and leaves it empty).
+
+Binary self-management commands (`version`, `upgrade`, `downgrade`) and
+developer tools (`e2e`) are deliberately outside the engine set -- a binary owns
+its own lifecycle. The standalone binary adds them separately in
+`cmd/planton/root.go`.
+
+When adding a new user-facing engine command, register it in
+`root.RegisterCommands` (and its contract test in `register_test.go`), not on
+the standalone root directly -- otherwise embedding hosts silently lose it.
+
+---
+
 ## Command Implementation Pattern
 
 ### Standard Handler Pattern

--- a/cmd/planton/root.go
+++ b/cmd/planton/root.go
@@ -1,5 +1,4 @@
 // Package planton provides the root command for the Planton CLI.
-// Auto-release test: CLI change triggers v{semver}.{YYYYMMDD}.{N} tag format.
 package planton
 
 import (
@@ -7,12 +6,8 @@ import (
 	"os"
 
 	"github.com/plantonhq/planton/cmd/planton/root"
-	"github.com/plantonhq/planton/internal/cli/flag"
 	"github.com/spf13/cobra"
 )
-
-// DefaultPlantonGitRepo is the default path for the local planton git repository
-const DefaultPlantonGitRepo = "~/scm/github.com/plantonhq/planton"
 
 var rootCmd = &cobra.Command{
 	Use:   "planton",
@@ -35,33 +30,14 @@ func init() {
 	// Enable -v as shorthand for --version (handled in Run function for colorful output)
 	rootCmd.Flags().BoolP("version", "v", false, "show version information")
 
-	// Local module flags - inherited by all subcommands
-	rootCmd.PersistentFlags().Bool(string(flag.LocalModule), false,
-		"Use local planton git repository for IaC modules instead of downloading")
-	rootCmd.PersistentFlags().String(string(flag.PlantonGitRepo), DefaultPlantonGitRepo,
-		"Path to local planton git repository (used with --local-module)")
-
+	// The engine command set and its persistent flags come from the shared
+	// embedding seam; the standalone binary owns its self-management commands
+	// and developer tools on top of it.
+	root.RegisterCommands(rootCmd, root.Options{})
 	rootCmd.AddCommand(
-		root.Apply,
-		root.Checkout,
-		root.Destroy,
 		root.Downgrade,
 		root.E2E,
-		root.Init,
-		root.Kustomize,
-		root.LoadManifest,
-		root.ModulesVersion,
-		root.Plan,
-		root.Pull,
-		root.Pulumi,
-		root.Refresh,
-		root.SecretCoverage,
-		root.Terraform,
-		root.Tofu,
 		root.Upgrade,
-		root.ValidateManifest,
-		root.ValidateOutputs,
-		root.ValidateRefs,
 		root.Version,
 	)
 }

--- a/cmd/planton/root/BUILD.bazel
+++ b/cmd/planton/root/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "root",
@@ -16,6 +16,7 @@ go_library(
         "pull.go",
         "pulumi.go",
         "refresh.go",
+        "register.go",
         "secret_coverage.go",
         "terraform.go",
         "tofu.go",
@@ -64,5 +65,15 @@ go_library(
         "@com_github_sirupsen_logrus//:logrus",
         "@com_github_spf13_cobra//:cobra",
         "@org_golang_google_protobuf//proto",
+    ],
+)
+
+go_test(
+    name = "root_test",
+    srcs = ["register_test.go"],
+    embed = [":root"],
+    deps = [
+        "//internal/cli/version",
+        "@com_github_spf13_cobra//:cobra",
     ],
 )

--- a/cmd/planton/root/register.go
+++ b/cmd/planton/root/register.go
@@ -1,0 +1,82 @@
+package root
+
+import (
+	"github.com/plantonhq/planton/internal/cli/flag"
+	"github.com/plantonhq/planton/internal/cli/version"
+	"github.com/spf13/cobra"
+)
+
+// DefaultPlantonGitRepo is the default local clone path of the Planton
+// open-source repository, used by --local-module to run IaC modules from a
+// working tree instead of downloaded release artifacts.
+const DefaultPlantonGitRepo = "~/scm/github.com/plantonhq/planton"
+
+// Options configures the engine command set for the binary that registers it.
+type Options struct {
+	// ModulesVersion pins the released IaC module artifacts
+	// (downloads.planton.dev/releases/<version>/...) that match the proto
+	// schemas compiled into the binary. The standalone planton binary carries
+	// its own version stamped via ldflags and leaves this empty; a host binary
+	// that embeds the engine as a Go module passes the resolved module version
+	// here so module downloads stay schema-consistent with the compiled-in
+	// protos. When neither is set, module resolution falls back to the git
+	// staging area.
+	ModulesVersion string
+}
+
+// RegisterCommands wires the Planton open-source engine's user-facing command
+// set onto parent, along with the persistent flags those commands require.
+//
+// This is the embedding contract: the standalone planton binary and any host
+// binary that embeds the engine (such as the Planton Platform CLI) register
+// commands through the same exported surface, so the two cannot drift.
+//
+// Binary self-management commands (version, upgrade, downgrade) and developer
+// tools (e2e) are deliberately not part of the engine set -- a binary owns its
+// own lifecycle. The standalone binary adds them separately.
+func RegisterCommands(parent *cobra.Command, opts Options) {
+	SetModulesVersion(opts.ModulesVersion)
+	RegisterPersistentFlags(parent)
+
+	parent.AddCommand(
+		Apply,
+		Checkout,
+		Destroy,
+		Init,
+		Kustomize,
+		LoadManifest,
+		ModulesVersion,
+		Plan,
+		Pull,
+		Pulumi,
+		Refresh,
+		SecretCoverage,
+		Terraform,
+		Tofu,
+		ValidateManifest,
+		ValidateOutputs,
+		ValidateRefs,
+	)
+}
+
+// RegisterPersistentFlags registers the flags every engine command resolves
+// through cobra's parent-child flag inheritance. A host that mounts individual
+// exported commands (rather than the full set via RegisterCommands) must still
+// call this on the mount point, or module resolution inside the commands fails
+// at flag lookup.
+func RegisterPersistentFlags(parent *cobra.Command) {
+	parent.PersistentFlags().Bool(string(flag.LocalModule), false,
+		"Use local planton git repository for IaC modules instead of downloading")
+	parent.PersistentFlags().String(string(flag.PlantonGitRepo), DefaultPlantonGitRepo,
+		"Path to local planton git repository (used with --local-module)")
+}
+
+// SetModulesVersion pins the released IaC module artifacts the engine
+// downloads (see Options.ModulesVersion). Exported for hosts that mount
+// individual commands instead of calling RegisterCommands. Empty input is a
+// no-op so a stamped standalone binary is never overwritten with nothing.
+func SetModulesVersion(v string) {
+	if v != "" {
+		version.Version = v
+	}
+}

--- a/cmd/planton/root/register_test.go
+++ b/cmd/planton/root/register_test.go
@@ -1,0 +1,70 @@
+package root
+
+import (
+	"testing"
+
+	"github.com/plantonhq/planton/internal/cli/version"
+	"github.com/spf13/cobra"
+)
+
+// The engine set is the embedding contract: every user-facing engine command
+// must be present, and binary self-management (version/upgrade/downgrade) and
+// developer tools (e2e) must not be.
+func TestRegisterCommands_EngineSet(t *testing.T) {
+	parent := &cobra.Command{Use: "host"}
+	RegisterCommands(parent, Options{})
+
+	want := []string{
+		"apply", "checkout", "destroy", "init", "kustomize", "load-manifest",
+		"modules-version", "plan", "pull", "pulumi", "refresh",
+		"secret-coverage", "terraform", "tofu", "validate-manifest",
+		"validate-outputs", "validate-refs",
+	}
+	got := map[string]bool{}
+	for _, c := range parent.Commands() {
+		got[c.Name()] = true
+	}
+	for _, name := range want {
+		if !got[name] {
+			t.Errorf("engine command %q not registered", name)
+		}
+	}
+	for _, excluded := range []string{"version", "upgrade", "downgrade", "e2e"} {
+		if got[excluded] {
+			t.Errorf("command %q must not be part of the engine set", excluded)
+		}
+	}
+}
+
+func TestRegisterCommands_PersistentFlags(t *testing.T) {
+	parent := &cobra.Command{Use: "host"}
+	RegisterCommands(parent, Options{})
+
+	if f := parent.PersistentFlags().Lookup("local-module"); f == nil {
+		t.Error("persistent flag --local-module not registered")
+	}
+	f := parent.PersistentFlags().Lookup("planton-git-repo")
+	if f == nil {
+		t.Fatal("persistent flag --planton-git-repo not registered")
+	}
+	if f.DefValue != DefaultPlantonGitRepo {
+		t.Errorf("--planton-git-repo default = %q, want %q", f.DefValue, DefaultPlantonGitRepo)
+	}
+}
+
+func TestSetModulesVersion(t *testing.T) {
+	original := version.Version
+	defer func() { version.Version = original }()
+
+	version.Version = ""
+	SetModulesVersion("v0.3.0")
+	if version.Version != "v0.3.0" {
+		t.Errorf("version = %q, want v0.3.0", version.Version)
+	}
+
+	// Empty input must never erase a stamped version.
+	SetModulesVersion("")
+	if version.Version != "v0.3.0" {
+		t.Errorf("empty SetModulesVersion overwrote stamped version: %q", version.Version)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `root.RegisterCommands(parent *cobra.Command, opts root.Options)` in `cmd/planton/root` as the single exported seam through which the engine's user-facing command set is mounted -- by the standalone `planton` binary and by host binaries that embed the engine as a Go module (the Planton Platform CLI). One registration surface means the standalone and embedded command trees cannot drift.
- The seam registers the persistent flags the commands resolve via cobra inheritance (`--local-module`, `--planton-git-repo`) and accepts `Options.ModulesVersion` so an embedding host can pin module artifact downloads (`downloads.planton.dev/releases/<version>/...`) to the engine version it compiled against. The standalone binary keeps its ldflags stamping and passes empty options.
- Binary self-management (`version`, `upgrade`, `downgrade`) and dev tools (`e2e`) stay outside the engine set -- a binary owns its own lifecycle; the standalone root adds them separately.
- Contract tests in `register_test.go` lock the engine set, the flag registration, and the never-erase-a-stamped-version rule. `cmd/planton/README.md` documents the embedding contract.

## Test plan

- [x] `go test ./cmd/...` green (new contract tests included)
- [x] `go vet ./cmd/... ./internal/...` clean; `gofmt` clean
- [x] `go test -race ./...`: same result as `origin/main` -- the only failures (`labelkeys`, `providerenvvars` guard) are pre-existing on untouched packages with zero dependency on `cmd/planton` (verified via `go list -deps`)
- [x] `make gazelle` run; BUILD.bazel diffs are mechanical
- [x] Built binary `--help` output identical to before the refactor

🤖 Generated with AI assistance (Cursor)