### PR TITLE
feat(provider/azure): add keyless web-identity (OIDC) auth via shared pulumi provider builders

### DIFF
--- a/apis/dev/planton/provider/azure/azureresourcegroup/v1/iac/pulumi/module/BUILD.bazel
+++ b/apis/dev/planton/provider/azure/azureresourcegroup/v1/iac/pulumi/module/BUILD.bazel
@@ -12,8 +12,8 @@ go_library(
     deps = [
         "//apis/dev/planton/provider/azure/azureresourcegroup/v1:azureresourcegroup",
         "//apis/dev/planton/shared/cloudresourcekind",
+        "//pkg/iac/pulumi/pulumimodule/provider/azure/pulumiazureprovider",
         "@com_github_pkg_errors//:errors",
-        "@com_github_pulumi_pulumi_azure_sdk_v6//go/azure",
         "@com_github_pulumi_pulumi_azure_sdk_v6//go/azure/core",
         "@com_github_pulumi_pulumi_sdk_v3//go/pulumi",
     ],

--- a/apis/dev/planton/provider/azure/azureresourcegroup/v1/iac/pulumi/module/main.go
+++ b/apis/dev/planton/provider/azure/azureresourcegroup/v1/iac/pulumi/module/main.go
@@ -3,24 +3,17 @@ package module
 import (
 	"github.com/pkg/errors"
 	azureresourcegroupv1 "github.com/plantonhq/planton/apis/dev/planton/provider/azure/azureresourcegroup/v1"
-	"github.com/pulumi/pulumi-azure/sdk/v6/go/azure"
+	"github.com/plantonhq/planton/pkg/iac/pulumi/pulumimodule/provider/azure/pulumiazureprovider"
 	"github.com/pulumi/pulumi-azure/sdk/v6/go/azure/core"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
 func Resources(ctx *pulumi.Context, stackInput *azureresourcegroupv1.AzureResourceGroupStackInput) error {
 	locals := initializeLocals(ctx, stackInput)
-	azureProviderConfig := stackInput.ProviderConfig
 
-	// Create azure provider using the credentials from the input
-	azureProvider, err := azure.NewProvider(ctx,
-		"azure",
-		&azure.ProviderArgs{
-			ClientId:       pulumi.String(azureProviderConfig.ClientId),
-			ClientSecret:   pulumi.String(azureProviderConfig.ClientSecret),
-			SubscriptionId: pulumi.String(azureProviderConfig.SubscriptionId),
-			TenantId:       pulumi.String(azureProviderConfig.TenantId),
-		})
+	// Build the Azure provider from the stack input via the shared builder, which resolves
+	// the right credential mechanism (static client secret, keyless web identity, or ambient chain).
+	azureProvider, err := pulumiazureprovider.Get(ctx, stackInput.ProviderConfig)
 	if err != nil {
 		return errors.Wrap(err, "failed to create azure provider")
 	}

--- a/apis/dev/planton/provider/azure/provider.pb.go
+++ b/apis/dev/planton/provider/azure/provider.pb.go
@@ -25,15 +25,20 @@ const (
 // AzureProviderConfig message represents the specification required to connect an Azure account.
 // This message consolidates all necessary input parameters to establish a connection with an Azure account,
 // ensuring accurate configuration and validation of credentials.
-// Fields include client ID, client secret, tenant ID, and subscription ID, providing a complete set of information
-// for securely connecting to Azure.
+// The identity coordinates (client ID, tenant ID, subscription ID) are always required; the credential is
+// supplied by exactly one of {client_secret, web_identity}. If neither is set, providers fall back to the
+// ambient Azure credential chain (e.g. a self-hosted runner's managed identity or `az` CLI login).
 type AzureProviderConfig struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// The Azure Client ID, which is used to identify the application making requests to Azure services.
-	// This is a required field, and it must be a valid non-empty string.
+	// The Azure Client ID, which identifies the application (service principal) making requests to
+	// Azure services. Required in every auth mode: static-secret auth authenticates this application
+	// with client_secret, and keyless web-identity auth exchanges the OIDC token for this same
+	// application via its federated identity credential.
 	ClientId string `protobuf:"bytes,1,opt,name=client_id,json=clientId,proto3" json:"client_id,omitempty"`
 	// The Azure Client Secret, which is used to authenticate the application with Azure services.
-	// This is a required field, and it must be a valid non-empty string.
+	// Required for static-credential auth; left empty for keyless web-identity auth (see web_identity
+	// below). The requirement is skipped when the field is empty (IGNORE_IF_ZERO_VALUE) so keyless
+	// configs validate.
 	ClientSecret string `protobuf:"bytes,2,opt,name=client_secret,json=clientSecret,proto3" json:"client_secret,omitempty"`
 	// The Azure Tenant ID, which uniquely identifies the Azure Active Directory (AAD) tenant.
 	// This is a required field, and it must be a valid non-empty string.
@@ -41,8 +46,13 @@ type AzureProviderConfig struct {
 	// The Azure Subscription ID, which uniquely identifies the Azure subscription.
 	// This is a required field, and it must be a valid non-empty string.
 	SubscriptionId string `protobuf:"bytes,4,opt,name=subscription_id,json=subscriptionId,proto3" json:"subscription_id,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// Keyless web-identity (OIDC) authentication. When set, the provider authenticates via Azure
+	// Workload Identity Federation instead of a static client secret -- so client_secret is left
+	// empty in this mode. Exactly one of {client_secret, web_identity} is populated; if neither is
+	// set the provider falls back to the ambient credential chain.
+	WebIdentity   *AzureWebIdentityProviderConfig `protobuf:"bytes,5,opt,name=web_identity,json=webIdentity,proto3" json:"web_identity,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *AzureProviderConfig) Reset() {
@@ -103,16 +113,91 @@ func (x *AzureProviderConfig) GetSubscriptionId() string {
 	return ""
 }
 
+func (x *AzureProviderConfig) GetWebIdentity() *AzureWebIdentityProviderConfig {
+	if x != nil {
+		return x.WebIdentity
+	}
+	return nil
+}
+
+// AzureWebIdentityProviderConfig holds the input for keyless OIDC federation: the caller mints a
+// short-lived OIDC JWT from an issuer it controls, and Azure exchanges it for an AAD access token
+// via the OAuth client-assertion flow, matched against a federated identity credential (an exact
+// issuer + subject + audience triple) on the target application. The token is opaque to Planton,
+// which is agnostic to the issuer (a platform-owned issuer, GitHub Actions, GitLab CI, etc.).
+//
+// The token is carried in memory (web_identity_token) and never written to disk: each pulumi
+// operation re-mints a fresh JWT before it runs, so a stack job's runtime is never bound by a
+// single token's TTL and no file-based provider refresh is needed.
+//
+// These provider-config fields are constructed by the caller (e.g. the Planton runner) at deploy
+// time, not supplied as user input in a resource spec, so they are intentionally outside the spec
+// secret-coverage surface and carry no `sensitive` annotation.
+//
+// Exchange site: both pulumi Azure SDKs (azure "classic" and azure-native) consume the inline
+// token natively via their provider-level UseOidc + OidcToken fields and perform the AAD
+// client-assertion exchange inside the provider plugin -- no exchange happens in Planton's
+// process, unlike the AWS builders which were forced into a builder-side STS exchange by an
+// upstream provider bug.
+type AzureWebIdentityProviderConfig struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The minted OIDC JWT presented to Azure AD as the client assertion, supplied inline (in
+	// memory). Maps to the pulumi Azure providers' OidcToken field.
+	WebIdentityToken string `protobuf:"bytes,1,opt,name=web_identity_token,json=webIdentityToken,proto3" json:"web_identity_token,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *AzureWebIdentityProviderConfig) Reset() {
+	*x = AzureWebIdentityProviderConfig{}
+	mi := &file_dev_planton_provider_azure_provider_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AzureWebIdentityProviderConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AzureWebIdentityProviderConfig) ProtoMessage() {}
+
+func (x *AzureWebIdentityProviderConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_dev_planton_provider_azure_provider_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AzureWebIdentityProviderConfig.ProtoReflect.Descriptor instead.
+func (*AzureWebIdentityProviderConfig) Descriptor() ([]byte, []int) {
+	return file_dev_planton_provider_azure_provider_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *AzureWebIdentityProviderConfig) GetWebIdentityToken() string {
+	if x != nil {
+		return x.WebIdentityToken
+	}
+	return ""
+}
+
 var File_dev_planton_provider_azure_provider_proto protoreflect.FileDescriptor
 
 const file_dev_planton_provider_azure_provider_proto_rawDesc = "" +
 	"\n" +
-	")dev/planton/provider/azure/provider.proto\x12\x1adev.planton.provider.azure\x1a\x1bbuf/validate/validate.proto\"\xbd\x01\n" +
+	")dev/planton/provider/azure/provider.proto\x12\x1adev.planton.provider.azure\x1a\x1bbuf/validate/validate.proto\"\x9c\x02\n" +
 	"\x13AzureProviderConfig\x12#\n" +
 	"\tclient_id\x18\x01 \x01(\tB\x06\xbaH\x03\xc8\x01\x01R\bclientId\x12+\n" +
-	"\rclient_secret\x18\x02 \x01(\tB\x06\xbaH\x03\xc8\x01\x01R\fclientSecret\x12#\n" +
+	"\rclient_secret\x18\x02 \x01(\tB\x06\xbaH\x03\xd8\x01\x01R\fclientSecret\x12#\n" +
 	"\ttenant_id\x18\x03 \x01(\tB\x06\xbaH\x03\xc8\x01\x01R\btenantId\x12/\n" +
-	"\x0fsubscription_id\x18\x04 \x01(\tB\x06\xbaH\x03\xc8\x01\x01R\x0esubscriptionIdB\xf9\x01\n" +
+	"\x0fsubscription_id\x18\x04 \x01(\tB\x06\xbaH\x03\xc8\x01\x01R\x0esubscriptionId\x12]\n" +
+	"\fweb_identity\x18\x05 \x01(\v2:.dev.planton.provider.azure.AzureWebIdentityProviderConfigR\vwebIdentity\"V\n" +
+	"\x1eAzureWebIdentityProviderConfig\x124\n" +
+	"\x12web_identity_token\x18\x01 \x01(\tB\x06\xbaH\x03\xc8\x01\x01R\x10webIdentityTokenB\xf9\x01\n" +
 	"\x1ecom.dev.planton.provider.azureB\rProviderProtoP\x01Z<github.com/plantonhq/planton/apis/dev/planton/provider/azure\xa2\x02\x04DPPA\xaa\x02\x1aDev.Planton.Provider.Azure\xca\x02\x1aDev\\Planton\\Provider\\Azure\xe2\x02&Dev\\Planton\\Provider\\Azure\\GPBMetadata\xea\x02\x1dDev::Planton::Provider::Azureb\x06proto3"
 
 var (
@@ -127,16 +212,18 @@ func file_dev_planton_provider_azure_provider_proto_rawDescGZIP() []byte {
 	return file_dev_planton_provider_azure_provider_proto_rawDescData
 }
 
-var file_dev_planton_provider_azure_provider_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
+var file_dev_planton_provider_azure_provider_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
 var file_dev_planton_provider_azure_provider_proto_goTypes = []any{
-	(*AzureProviderConfig)(nil), // 0: dev.planton.provider.azure.AzureProviderConfig
+	(*AzureProviderConfig)(nil),            // 0: dev.planton.provider.azure.AzureProviderConfig
+	(*AzureWebIdentityProviderConfig)(nil), // 1: dev.planton.provider.azure.AzureWebIdentityProviderConfig
 }
 var file_dev_planton_provider_azure_provider_proto_depIdxs = []int32{
-	0, // [0:0] is the sub-list for method output_type
-	0, // [0:0] is the sub-list for method input_type
-	0, // [0:0] is the sub-list for extension type_name
-	0, // [0:0] is the sub-list for extension extendee
-	0, // [0:0] is the sub-list for field type_name
+	1, // 0: dev.planton.provider.azure.AzureProviderConfig.web_identity:type_name -> dev.planton.provider.azure.AzureWebIdentityProviderConfig
+	1, // [1:1] is the sub-list for method output_type
+	1, // [1:1] is the sub-list for method input_type
+	1, // [1:1] is the sub-list for extension type_name
+	1, // [1:1] is the sub-list for extension extendee
+	0, // [0:1] is the sub-list for field type_name
 }
 
 func init() { file_dev_planton_provider_azure_provider_proto_init() }
@@ -150,7 +237,7 @@ func file_dev_planton_provider_azure_provider_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_dev_planton_provider_azure_provider_proto_rawDesc), len(file_dev_planton_provider_azure_provider_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   1,
+			NumMessages:   2,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/apis/dev/planton/provider/azure/provider.proto
+++ b/apis/dev/planton/provider/azure/provider.proto
@@ -7,16 +7,21 @@ import "buf/validate/validate.proto";
 // AzureProviderConfig message represents the specification required to connect an Azure account.
 // This message consolidates all necessary input parameters to establish a connection with an Azure account,
 // ensuring accurate configuration and validation of credentials.
-// Fields include client ID, client secret, tenant ID, and subscription ID, providing a complete set of information
-// for securely connecting to Azure.
+// The identity coordinates (client ID, tenant ID, subscription ID) are always required; the credential is
+// supplied by exactly one of {client_secret, web_identity}. If neither is set, providers fall back to the
+// ambient Azure credential chain (e.g. a self-hosted runner's managed identity or `az` CLI login).
 message AzureProviderConfig {
-  // The Azure Client ID, which is used to identify the application making requests to Azure services.
-  // This is a required field, and it must be a valid non-empty string.
+  // The Azure Client ID, which identifies the application (service principal) making requests to
+  // Azure services. Required in every auth mode: static-secret auth authenticates this application
+  // with client_secret, and keyless web-identity auth exchanges the OIDC token for this same
+  // application via its federated identity credential.
   string client_id = 1 [(buf.validate.field).required = true];
 
   // The Azure Client Secret, which is used to authenticate the application with Azure services.
-  // This is a required field, and it must be a valid non-empty string.
-  string client_secret = 2 [(buf.validate.field).required = true];
+  // Required for static-credential auth; left empty for keyless web-identity auth (see web_identity
+  // below). The requirement is skipped when the field is empty (IGNORE_IF_ZERO_VALUE) so keyless
+  // configs validate.
+  string client_secret = 2 [(buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE];
 
   // The Azure Tenant ID, which uniquely identifies the Azure Active Directory (AAD) tenant.
   // This is a required field, and it must be a valid non-empty string.
@@ -25,4 +30,35 @@ message AzureProviderConfig {
   // The Azure Subscription ID, which uniquely identifies the Azure subscription.
   // This is a required field, and it must be a valid non-empty string.
   string subscription_id = 4 [(buf.validate.field).required = true];
+
+  // Keyless web-identity (OIDC) authentication. When set, the provider authenticates via Azure
+  // Workload Identity Federation instead of a static client secret -- so client_secret is left
+  // empty in this mode. Exactly one of {client_secret, web_identity} is populated; if neither is
+  // set the provider falls back to the ambient credential chain.
+  AzureWebIdentityProviderConfig web_identity = 5;
+}
+
+// AzureWebIdentityProviderConfig holds the input for keyless OIDC federation: the caller mints a
+// short-lived OIDC JWT from an issuer it controls, and Azure exchanges it for an AAD access token
+// via the OAuth client-assertion flow, matched against a federated identity credential (an exact
+// issuer + subject + audience triple) on the target application. The token is opaque to Planton,
+// which is agnostic to the issuer (a platform-owned issuer, GitHub Actions, GitLab CI, etc.).
+//
+// The token is carried in memory (web_identity_token) and never written to disk: each pulumi
+// operation re-mints a fresh JWT before it runs, so a stack job's runtime is never bound by a
+// single token's TTL and no file-based provider refresh is needed.
+//
+// These provider-config fields are constructed by the caller (e.g. the Planton runner) at deploy
+// time, not supplied as user input in a resource spec, so they are intentionally outside the spec
+// secret-coverage surface and carry no `sensitive` annotation.
+//
+// Exchange site: both pulumi Azure SDKs (azure "classic" and azure-native) consume the inline
+// token natively via their provider-level UseOidc + OidcToken fields and perform the AAD
+// client-assertion exchange inside the provider plugin -- no exchange happens in Planton's
+// process, unlike the AWS builders which were forced into a builder-side STS exchange by an
+// upstream provider bug.
+message AzureWebIdentityProviderConfig {
+  // The minted OIDC JWT presented to Azure AD as the client assertion, supplied inline (in
+  // memory). Maps to the pulumi Azure providers' OidcToken field.
+  string web_identity_token = 1 [(buf.validate.field).required = true];
 }

--- a/bazel-planton-copy
+++ b/bazel-planton-copy
@@ -1,0 +1,1 @@
+/private/var/tmp/_bazel_swarup/3c72f70beded1486e8e5eb18393c3eea/execroot/_main

--- a/pkg/iac/pulumi/pulumimodule/provider/azure/pulumiazurenativeprovider/BUILD.bazel
+++ b/pkg/iac/pulumi/pulumimodule/provider/azure/pulumiazurenativeprovider/BUILD.bazel
@@ -1,0 +1,27 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "pulumiazurenativeprovider",
+    srcs = ["provider.go"],
+    importpath = "github.com/plantonhq/planton/pkg/iac/pulumi/pulumimodule/provider/azure/pulumiazurenativeprovider",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//apis/dev/planton/provider/azure",
+        "//pkg/iac/pulumi/pulumimodule/pulumi/pulumioutput",
+        "@com_github_pkg_errors//:errors",
+        "@com_github_pulumi_pulumi_azure_native_sdk_v3//:pulumi-azure-native-sdk",
+        "@com_github_pulumi_pulumi_sdk_v3//go/pulumi",
+    ],
+)
+
+go_test(
+    name = "pulumiazurenativeprovider_test",
+    srcs = ["provider_test.go"],
+    embed = [":pulumiazurenativeprovider"],
+    deps = [
+        "//apis/dev/planton/provider/azure",
+        "@com_github_pulumi_pulumi_sdk_v3//go/pulumi",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/iac/pulumi/pulumimodule/provider/azure/pulumiazurenativeprovider/provider.go
+++ b/pkg/iac/pulumi/pulumimodule/provider/azure/pulumiazurenativeprovider/provider.go
@@ -1,0 +1,139 @@
+// Package pulumiazurenativeprovider is the convergent place where Azure pulumi-azure-native
+// modules build their azurenative.Provider from the stack input's AzureProviderConfig. It mirrors
+// pulumiazureprovider (the pulumi-azure "classic" builder) so a coding agent can learn both Azure
+// credential-resolution paths from one shape.
+//
+// It dispatches on which fields of AzureProviderConfig are populated, supporting every auth mode
+// with a single seam:
+//   - web_identity set  -> keyless OIDC federation. The minted JWT is handed to the provider
+//     inline (UseOidc + OidcToken) together with the identity coordinates; the provider plugin
+//     performs the AAD client-assertion exchange itself, out of our process.
+//   - client_secret set -> static service-principal credentials (today's four-field mode).
+//   - neither           -> identity coordinates only when present, no credential. The provider
+//     falls back to the SDK's ambient credential chain (e.g. a self-hosted runner's managed
+//     identity or `az` CLI login).
+//
+// SECURITY -- the one structural difference from the classic builder: this azure-native (v3)
+// SDK's NewProvider auto-secret-wraps ClientId/ClientSecret/ClientCertificatePassword but NOT
+// OidcToken, so an unwrapped token would land in Pulumi state and `preview` output in plaintext.
+// This builder therefore wraps the token with pulumi.ToSecret itself. The classic (v6) SDK
+// auto-wraps OidcToken, so its builder deliberately does not.
+//
+// Like the classic builder, there is NO builder-side token exchange: the AWS builders exchange
+// the web-identity token themselves only because pulumi-aws's provider-native path is broken
+// upstream (pulumi-aws#6228); the pulumi Azure providers consume the inline token natively. Do
+// not "converge" this builder toward the AWS workaround shape.
+//
+// It deliberately never passes empty-string credential fields to azurenative.NewProvider: the
+// inline pre-builder modules passed all four fields unconditionally, which conflates "not set"
+// with "set to empty" and blocks the ambient credential chain from ever engaging.
+package pulumiazurenativeprovider
+
+import (
+	"fmt"
+	"reflect"
+
+	azureprovider "github.com/plantonhq/planton/apis/dev/planton/provider/azure"
+	"github.com/plantonhq/planton/pkg/iac/pulumi/pulumimodule/pulumi/pulumioutput"
+
+	"github.com/pkg/errors"
+	azurenative "github.com/pulumi/pulumi-azure-native-sdk/v3"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+// Get builds an azure-native Provider from the given AzureProviderConfig. There is no region
+// argument: the Azure provider is not region-scoped -- each resource carries its own Location.
+// nameSuffixes disambiguate the provider resource name when a module needs more than one provider.
+func Get(ctx *pulumi.Context, azureProviderConfig *azureprovider.AzureProviderConfig,
+	nameSuffixes ...string) (*azurenative.Provider, error) {
+	providerArgs, err := buildProviderArgs(azureProviderConfig)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build azure-native provider args")
+	}
+
+	azureNativeProvider, err := azurenative.NewProvider(ctx, ProviderResourceName(nameSuffixes), providerArgs)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create azure-native provider")
+	}
+
+	return azureNativeProvider, nil
+}
+
+// buildProviderArgs is the pure, side-effect-free core of the builder: it maps an
+// AzureProviderConfig to azurenative.ProviderArgs. It is split out from Get so the credential
+// dispatch (the security-critical part) is unit-testable without a Pulumi context.
+func buildProviderArgs(azureProviderConfig *azureprovider.AzureProviderConfig) (*azurenative.ProviderArgs, error) {
+	providerArgs := &azurenative.ProviderArgs{}
+
+	// No config -> ambient credential chain.
+	if azureProviderConfig == nil {
+		return providerArgs, nil
+	}
+
+	setIdentityCoordinates(providerArgs, azureProviderConfig)
+
+	switch {
+	case azureProviderConfig.GetWebIdentity() != nil:
+		webIdentity := azureProviderConfig.GetWebIdentity()
+		if webIdentity.GetWebIdentityToken() == "" {
+			return nil, errors.New("web_identity is set but web_identity_token is empty")
+		}
+
+		// The provider plugin exchanges the inline token via the AAD client-assertion flow.
+		// This SDK's NewProvider does NOT auto-secret-wrap OidcToken (unlike the classic SDK),
+		// so wrap it here to keep the minted JWT out of plaintext Pulumi state.
+		providerArgs.UseOidc = pulumi.Bool(true)
+		providerArgs.OidcToken = pulumi.ToSecret(pulumi.String(webIdentity.GetWebIdentityToken())).(pulumi.StringInput)
+
+	case azureProviderConfig.GetClientSecret() != "":
+		// Static service-principal credentials.
+		providerArgs.ClientSecret = pulumi.String(azureProviderConfig.GetClientSecret())
+
+	default:
+		// No explicit credential: the provider resolves credentials from the SDK's ambient
+		// chain (e.g. a self-hosted runner's managed identity or `az` CLI login).
+	}
+
+	return providerArgs, nil
+}
+
+// setIdentityCoordinates copies the non-credential identity fields (client, tenant,
+// subscription), skipping empty values so an absent field never reaches the provider as an
+// empty string.
+func setIdentityCoordinates(providerArgs *azurenative.ProviderArgs, azureProviderConfig *azureprovider.AzureProviderConfig) {
+	if azureProviderConfig.GetClientId() != "" {
+		providerArgs.ClientId = pulumi.String(azureProviderConfig.GetClientId())
+	}
+	if azureProviderConfig.GetTenantId() != "" {
+		providerArgs.TenantId = pulumi.String(azureProviderConfig.GetTenantId())
+	}
+	if azureProviderConfig.GetSubscriptionId() != "" {
+		providerArgs.SubscriptionId = pulumi.String(azureProviderConfig.GetSubscriptionId())
+	}
+}
+
+// ProviderResourceName returns the Pulumi resource name for the azure-native provider.
+//
+// The base is intentionally "azure": every Azure module historically created its provider with
+// exactly this name (azurenative.NewProvider(ctx, "azure", ...)). Pulumi tracks providers by
+// resource name, so keeping it stable lets existing modules adopt this shared builder without
+// triggering a provider replacement -- and the resource churn that would follow -- in
+// already-provisioned stacks. Do not rename without a state-migration plan. (No module uses both
+// the classic and native SDKs in one program, so the shared base name never collides.)
+func ProviderResourceName(suffixes []string) string {
+	name := "azure"
+	for _, s := range suffixes {
+		name = fmt.Sprintf("%s-%s", name, s)
+	}
+	return name
+}
+
+// PulumiOutputName builds a stable, prefixed output name for Azure resources, mirroring the
+// helper exposed by the other per-cloud provider builders.
+func PulumiOutputName(r interface{}, name string, suffixes ...string) string {
+	outputName := fmt.Sprintf("azure_%s", pulumioutput.Name(reflect.TypeOf(r), name))
+	for _, s := range suffixes {
+		outputName = fmt.Sprintf("%s_%s", outputName, s)
+	}
+	return outputName
+}

--- a/pkg/iac/pulumi/pulumimodule/provider/azure/pulumiazurenativeprovider/provider_test.go
+++ b/pkg/iac/pulumi/pulumimodule/provider/azure/pulumiazurenativeprovider/provider_test.go
@@ -1,0 +1,127 @@
+package pulumiazurenativeprovider
+
+import (
+	"testing"
+
+	azureprovider "github.com/plantonhq/planton/apis/dev/planton/provider/azure"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildProviderArgs_NilConfig_Ambient(t *testing.T) {
+	args, err := buildProviderArgs(nil)
+	require.NoError(t, err)
+	require.NotNil(t, args)
+
+	assert.Nil(t, args.ClientId)
+	assert.Nil(t, args.ClientSecret)
+	assert.Nil(t, args.TenantId)
+	assert.Nil(t, args.SubscriptionId)
+	assert.Nil(t, args.UseOidc)
+	assert.Nil(t, args.OidcToken)
+}
+
+func TestBuildProviderArgs_RunnerMode_IdentityCoordinatesOnly(t *testing.T) {
+	// No client secret and no web identity -> identity coordinates only (ambient chain).
+	cfg := &azureprovider.AzureProviderConfig{
+		ClientId:       "11111111-1111-1111-1111-111111111111",
+		TenantId:       "22222222-2222-2222-2222-222222222222",
+		SubscriptionId: "33333333-3333-3333-3333-333333333333",
+	}
+
+	args, err := buildProviderArgs(cfg)
+	require.NoError(t, err)
+
+	assert.Equal(t, pulumi.String("11111111-1111-1111-1111-111111111111"), args.ClientId)
+	assert.Equal(t, pulumi.String("22222222-2222-2222-2222-222222222222"), args.TenantId)
+	assert.Equal(t, pulumi.String("33333333-3333-3333-3333-333333333333"), args.SubscriptionId)
+	assert.Nil(t, args.ClientSecret)
+	assert.Nil(t, args.UseOidc)
+	assert.Nil(t, args.OidcToken)
+}
+
+func TestBuildProviderArgs_StaticCredentials(t *testing.T) {
+	cfg := &azureprovider.AzureProviderConfig{
+		ClientId:       "11111111-1111-1111-1111-111111111111",
+		ClientSecret:   "static-client-secret",
+		TenantId:       "22222222-2222-2222-2222-222222222222",
+		SubscriptionId: "33333333-3333-3333-3333-333333333333",
+	}
+
+	args, err := buildProviderArgs(cfg)
+	require.NoError(t, err)
+
+	assert.Equal(t, pulumi.String("11111111-1111-1111-1111-111111111111"), args.ClientId)
+	assert.Equal(t, pulumi.String("static-client-secret"), args.ClientSecret)
+	assert.Equal(t, pulumi.String("22222222-2222-2222-2222-222222222222"), args.TenantId)
+	assert.Equal(t, pulumi.String("33333333-3333-3333-3333-333333333333"), args.SubscriptionId)
+	// Static and keyless are mutually exclusive.
+	assert.Nil(t, args.UseOidc)
+	assert.Nil(t, args.OidcToken)
+}
+
+func TestBuildProviderArgs_WebIdentity_SetsSecretWrappedOidcToken(t *testing.T) {
+	cfg := &azureprovider.AzureProviderConfig{
+		ClientId:       "11111111-1111-1111-1111-111111111111",
+		TenantId:       "22222222-2222-2222-2222-222222222222",
+		SubscriptionId: "33333333-3333-3333-3333-333333333333",
+		WebIdentity: &azureprovider.AzureWebIdentityProviderConfig{
+			WebIdentityToken: "eyJhbGciOiJSUzI1NiJ9.payload.sig",
+		},
+	}
+
+	args, err := buildProviderArgs(cfg)
+	require.NoError(t, err)
+
+	assert.Equal(t, pulumi.Bool(true), args.UseOidc)
+	// This SDK's NewProvider does NOT auto-secret-wrap OidcToken, so the builder must: the
+	// token is present but secret-wrapped (an Output), never a bare pulumi.String.
+	require.NotNil(t, args.OidcToken)
+	assert.NotEqual(t, pulumi.String("eyJhbGciOiJSUzI1NiJ9.payload.sig"), args.OidcToken)
+	assert.Equal(t, pulumi.String("11111111-1111-1111-1111-111111111111"), args.ClientId)
+	assert.Equal(t, pulumi.String("22222222-2222-2222-2222-222222222222"), args.TenantId)
+	assert.Equal(t, pulumi.String("33333333-3333-3333-3333-333333333333"), args.SubscriptionId)
+	// Keyless must never carry a client secret.
+	assert.Nil(t, args.ClientSecret)
+}
+
+func TestBuildProviderArgs_WebIdentity_TakesPrecedenceOverStaleSecret(t *testing.T) {
+	// A config carrying both dispatches to keyless: web identity is the deliberate mode
+	// switch, a lingering client_secret must not win.
+	cfg := &azureprovider.AzureProviderConfig{
+		ClientId:       "11111111-1111-1111-1111-111111111111",
+		ClientSecret:   "stale-client-secret",
+		TenantId:       "22222222-2222-2222-2222-222222222222",
+		SubscriptionId: "33333333-3333-3333-3333-333333333333",
+		WebIdentity: &azureprovider.AzureWebIdentityProviderConfig{
+			WebIdentityToken: "eyJhbGciOiJSUzI1NiJ9.payload.sig",
+		},
+	}
+
+	args, err := buildProviderArgs(cfg)
+	require.NoError(t, err)
+
+	assert.Equal(t, pulumi.Bool(true), args.UseOidc)
+	assert.NotNil(t, args.OidcToken)
+	assert.Nil(t, args.ClientSecret)
+}
+
+func TestBuildProviderArgs_WebIdentity_MissingToken_Errors(t *testing.T) {
+	cfg := &azureprovider.AzureProviderConfig{
+		ClientId:       "11111111-1111-1111-1111-111111111111",
+		TenantId:       "22222222-2222-2222-2222-222222222222",
+		SubscriptionId: "33333333-3333-3333-3333-333333333333",
+		WebIdentity:    &azureprovider.AzureWebIdentityProviderConfig{},
+	}
+
+	_, err := buildProviderArgs(cfg)
+	assert.Error(t, err)
+}
+
+func TestProviderResourceName(t *testing.T) {
+	// State continuity: the base name must stay "azure".
+	assert.Equal(t, "azure", ProviderResourceName(nil))
+	assert.Equal(t, "azure-replica", ProviderResourceName([]string{"replica"}))
+	assert.Equal(t, "azure-aks-nodepool", ProviderResourceName([]string{"aks", "nodepool"}))
+}

--- a/pkg/iac/pulumi/pulumimodule/provider/azure/pulumiazureprovider/BUILD.bazel
+++ b/pkg/iac/pulumi/pulumimodule/provider/azure/pulumiazureprovider/BUILD.bazel
@@ -1,0 +1,27 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "pulumiazureprovider",
+    srcs = ["provider.go"],
+    importpath = "github.com/plantonhq/planton/pkg/iac/pulumi/pulumimodule/provider/azure/pulumiazureprovider",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//apis/dev/planton/provider/azure",
+        "//pkg/iac/pulumi/pulumimodule/pulumi/pulumioutput",
+        "@com_github_pkg_errors//:errors",
+        "@com_github_pulumi_pulumi_azure_sdk_v6//go/azure",
+        "@com_github_pulumi_pulumi_sdk_v3//go/pulumi",
+    ],
+)
+
+go_test(
+    name = "pulumiazureprovider_test",
+    srcs = ["provider_test.go"],
+    embed = [":pulumiazureprovider"],
+    deps = [
+        "//apis/dev/planton/provider/azure",
+        "@com_github_pulumi_pulumi_sdk_v3//go/pulumi",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/iac/pulumi/pulumimodule/provider/azure/pulumiazureprovider/provider.go
+++ b/pkg/iac/pulumi/pulumimodule/provider/azure/pulumiazureprovider/provider.go
@@ -1,0 +1,145 @@
+// Package pulumiazureprovider is the single, convergent place where every Azure pulumi-azure
+// "classic" module builds its azure.Provider from the stack input's AzureProviderConfig. It
+// mirrors the sibling per-cloud builders (e.g. pulumiazurenativeprovider, pulumiawsprovider,
+// pulumigoogleprovider) so a coding agent can learn the Azure credential-resolution path by
+// reading one file.
+//
+// It dispatches on which fields of AzureProviderConfig are populated, supporting every auth mode
+// with a single seam:
+//   - web_identity set  -> keyless OIDC federation. The minted JWT is handed to the provider
+//     inline (UseOidc + OidcToken) together with the identity coordinates; the provider plugin
+//     performs the AAD client-assertion exchange itself, out of our process.
+//   - client_secret set -> static service-principal credentials (today's four-field mode).
+//   - neither           -> identity coordinates only when present, no credential. The provider
+//     falls back to the SDK's ambient credential chain (e.g. a self-hosted runner's managed
+//     identity or `az` CLI login).
+//
+// Why NO builder-side token exchange (deliberate contrast with the AWS builders): the AWS
+// builders exchange the web-identity token themselves only because pulumi-aws's provider-native
+// path is broken upstream (pulumi-aws#6228). The pulumi-azure providers consume the inline token
+// natively -- the plugin sends it as the OAuth client_assertion and gets the AAD access token --
+// so a builder-side exchange here would add a dependency and put credentials in our process for
+// zero benefit. Do not "converge" this builder toward the AWS workaround shape.
+//
+// Freshness: the inline token is consumed at provider configure time and the resulting AAD access
+// token is provider-managed for the run. Each pulumi operation re-runs the module program with a
+// freshly minted JWT, so the exchange always sees a fresh token whose validity covers that one
+// operation. No token is ever written to disk.
+//
+// Secrecy: this classic (v6) SDK's NewProvider auto-secret-wraps OidcToken (along with ClientId,
+// ClientSecret, etc.), so the builder passes the plain string and must NOT double-wrap it. The
+// azure-native (v3) SDK does NOT auto-wrap OidcToken -- that difference is owned by the sibling
+// pulumiazurenativeprovider, which wraps it explicitly.
+//
+// It deliberately never passes empty-string credential fields to azure.NewProvider: the inline
+// pre-builder modules passed all four fields unconditionally, which conflates "not set" with
+// "set to empty" and blocks the ambient credential chain from ever engaging.
+package pulumiazureprovider
+
+import (
+	"fmt"
+	"reflect"
+
+	azureprovider "github.com/plantonhq/planton/apis/dev/planton/provider/azure"
+	"github.com/plantonhq/planton/pkg/iac/pulumi/pulumimodule/pulumi/pulumioutput"
+
+	"github.com/pkg/errors"
+	"github.com/pulumi/pulumi-azure/sdk/v6/go/azure"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+// Get builds an azure.Provider from the given AzureProviderConfig. There is no region argument:
+// unlike AWS, the Azure provider is not region-scoped -- each resource carries its own Location.
+// nameSuffixes disambiguate the provider resource name when a module needs more than one provider.
+func Get(ctx *pulumi.Context, azureProviderConfig *azureprovider.AzureProviderConfig,
+	nameSuffixes ...string) (*azure.Provider, error) {
+	providerArgs, err := buildProviderArgs(azureProviderConfig)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build azure provider args")
+	}
+
+	azureProvider, err := azure.NewProvider(ctx, ProviderResourceName(nameSuffixes), providerArgs)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create azure provider")
+	}
+
+	return azureProvider, nil
+}
+
+// buildProviderArgs is the pure, side-effect-free core of the builder: it maps an
+// AzureProviderConfig to azure.ProviderArgs. It is split out from Get so the credential dispatch
+// (the security-critical part) is unit-testable without a Pulumi context. Unlike the AWS builders
+// it needs no injectable exchange seam -- the provider plugin does the token exchange itself.
+func buildProviderArgs(azureProviderConfig *azureprovider.AzureProviderConfig) (*azure.ProviderArgs, error) {
+	providerArgs := &azure.ProviderArgs{}
+
+	// No config -> ambient credential chain.
+	if azureProviderConfig == nil {
+		return providerArgs, nil
+	}
+
+	setIdentityCoordinates(providerArgs, azureProviderConfig)
+
+	switch {
+	case azureProviderConfig.GetWebIdentity() != nil:
+		webIdentity := azureProviderConfig.GetWebIdentity()
+		if webIdentity.GetWebIdentityToken() == "" {
+			return nil, errors.New("web_identity is set but web_identity_token is empty")
+		}
+
+		// The provider plugin exchanges the inline token via the AAD client-assertion flow.
+		// This SDK's NewProvider auto-secret-wraps OidcToken, so pass the plain string here.
+		providerArgs.UseOidc = pulumi.Bool(true)
+		providerArgs.OidcToken = pulumi.String(webIdentity.GetWebIdentityToken())
+
+	case azureProviderConfig.GetClientSecret() != "":
+		// Static service-principal credentials.
+		providerArgs.ClientSecret = pulumi.String(azureProviderConfig.GetClientSecret())
+
+	default:
+		// No explicit credential: the provider resolves credentials from the SDK's ambient
+		// chain (e.g. a self-hosted runner's managed identity or `az` CLI login).
+	}
+
+	return providerArgs, nil
+}
+
+// setIdentityCoordinates copies the non-credential identity fields (client, tenant,
+// subscription), skipping empty values so an absent field never reaches the provider as an
+// empty string.
+func setIdentityCoordinates(providerArgs *azure.ProviderArgs, azureProviderConfig *azureprovider.AzureProviderConfig) {
+	if azureProviderConfig.GetClientId() != "" {
+		providerArgs.ClientId = pulumi.String(azureProviderConfig.GetClientId())
+	}
+	if azureProviderConfig.GetTenantId() != "" {
+		providerArgs.TenantId = pulumi.String(azureProviderConfig.GetTenantId())
+	}
+	if azureProviderConfig.GetSubscriptionId() != "" {
+		providerArgs.SubscriptionId = pulumi.String(azureProviderConfig.GetSubscriptionId())
+	}
+}
+
+// ProviderResourceName returns the Pulumi resource name for the Azure provider.
+//
+// The base is intentionally "azure": every Azure module historically created its provider with
+// exactly this name (azure.NewProvider(ctx, "azure", ...)). Pulumi tracks providers by resource
+// name, so keeping it stable lets existing modules adopt this shared builder without triggering
+// a provider replacement -- and the resource churn that would follow -- in already-provisioned
+// stacks. Do not rename without a state-migration plan.
+func ProviderResourceName(suffixes []string) string {
+	name := "azure"
+	for _, s := range suffixes {
+		name = fmt.Sprintf("%s-%s", name, s)
+	}
+	return name
+}
+
+// PulumiOutputName builds a stable, prefixed output name for Azure resources, mirroring the
+// helper exposed by the other per-cloud provider builders.
+func PulumiOutputName(r interface{}, name string, suffixes ...string) string {
+	outputName := fmt.Sprintf("azure_%s", pulumioutput.Name(reflect.TypeOf(r), name))
+	for _, s := range suffixes {
+		outputName = fmt.Sprintf("%s_%s", outputName, s)
+	}
+	return outputName
+}

--- a/pkg/iac/pulumi/pulumimodule/provider/azure/pulumiazureprovider/provider_test.go
+++ b/pkg/iac/pulumi/pulumimodule/provider/azure/pulumiazureprovider/provider_test.go
@@ -1,0 +1,126 @@
+package pulumiazureprovider
+
+import (
+	"testing"
+
+	azureprovider "github.com/plantonhq/planton/apis/dev/planton/provider/azure"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildProviderArgs_NilConfig_Ambient(t *testing.T) {
+	args, err := buildProviderArgs(nil)
+	require.NoError(t, err)
+	require.NotNil(t, args)
+
+	assert.Nil(t, args.ClientId)
+	assert.Nil(t, args.ClientSecret)
+	assert.Nil(t, args.TenantId)
+	assert.Nil(t, args.SubscriptionId)
+	assert.Nil(t, args.UseOidc)
+	assert.Nil(t, args.OidcToken)
+}
+
+func TestBuildProviderArgs_RunnerMode_IdentityCoordinatesOnly(t *testing.T) {
+	// No client secret and no web identity -> identity coordinates only (ambient chain).
+	cfg := &azureprovider.AzureProviderConfig{
+		ClientId:       "11111111-1111-1111-1111-111111111111",
+		TenantId:       "22222222-2222-2222-2222-222222222222",
+		SubscriptionId: "33333333-3333-3333-3333-333333333333",
+	}
+
+	args, err := buildProviderArgs(cfg)
+	require.NoError(t, err)
+
+	assert.Equal(t, pulumi.String("11111111-1111-1111-1111-111111111111"), args.ClientId)
+	assert.Equal(t, pulumi.String("22222222-2222-2222-2222-222222222222"), args.TenantId)
+	assert.Equal(t, pulumi.String("33333333-3333-3333-3333-333333333333"), args.SubscriptionId)
+	assert.Nil(t, args.ClientSecret)
+	assert.Nil(t, args.UseOidc)
+	assert.Nil(t, args.OidcToken)
+}
+
+func TestBuildProviderArgs_StaticCredentials(t *testing.T) {
+	cfg := &azureprovider.AzureProviderConfig{
+		ClientId:       "11111111-1111-1111-1111-111111111111",
+		ClientSecret:   "static-client-secret",
+		TenantId:       "22222222-2222-2222-2222-222222222222",
+		SubscriptionId: "33333333-3333-3333-3333-333333333333",
+	}
+
+	args, err := buildProviderArgs(cfg)
+	require.NoError(t, err)
+
+	assert.Equal(t, pulumi.String("11111111-1111-1111-1111-111111111111"), args.ClientId)
+	assert.Equal(t, pulumi.String("static-client-secret"), args.ClientSecret)
+	assert.Equal(t, pulumi.String("22222222-2222-2222-2222-222222222222"), args.TenantId)
+	assert.Equal(t, pulumi.String("33333333-3333-3333-3333-333333333333"), args.SubscriptionId)
+	// Static and keyless are mutually exclusive.
+	assert.Nil(t, args.UseOidc)
+	assert.Nil(t, args.OidcToken)
+}
+
+func TestBuildProviderArgs_WebIdentity_SetsInlineOidcToken(t *testing.T) {
+	cfg := &azureprovider.AzureProviderConfig{
+		ClientId:       "11111111-1111-1111-1111-111111111111",
+		TenantId:       "22222222-2222-2222-2222-222222222222",
+		SubscriptionId: "33333333-3333-3333-3333-333333333333",
+		WebIdentity: &azureprovider.AzureWebIdentityProviderConfig{
+			WebIdentityToken: "eyJhbGciOiJSUzI1NiJ9.payload.sig",
+		},
+	}
+
+	args, err := buildProviderArgs(cfg)
+	require.NoError(t, err)
+
+	assert.Equal(t, pulumi.Bool(true), args.UseOidc)
+	// This classic SDK's NewProvider auto-secret-wraps OidcToken, so the builder passes the
+	// plain string and must not double-wrap it.
+	assert.Equal(t, pulumi.String("eyJhbGciOiJSUzI1NiJ9.payload.sig"), args.OidcToken)
+	assert.Equal(t, pulumi.String("11111111-1111-1111-1111-111111111111"), args.ClientId)
+	assert.Equal(t, pulumi.String("22222222-2222-2222-2222-222222222222"), args.TenantId)
+	assert.Equal(t, pulumi.String("33333333-3333-3333-3333-333333333333"), args.SubscriptionId)
+	// Keyless must never carry a client secret.
+	assert.Nil(t, args.ClientSecret)
+}
+
+func TestBuildProviderArgs_WebIdentity_TakesPrecedenceOverStaleSecret(t *testing.T) {
+	// A config carrying both dispatches to keyless: web identity is the deliberate mode
+	// switch, a lingering client_secret must not win.
+	cfg := &azureprovider.AzureProviderConfig{
+		ClientId:       "11111111-1111-1111-1111-111111111111",
+		ClientSecret:   "stale-client-secret",
+		TenantId:       "22222222-2222-2222-2222-222222222222",
+		SubscriptionId: "33333333-3333-3333-3333-333333333333",
+		WebIdentity: &azureprovider.AzureWebIdentityProviderConfig{
+			WebIdentityToken: "eyJhbGciOiJSUzI1NiJ9.payload.sig",
+		},
+	}
+
+	args, err := buildProviderArgs(cfg)
+	require.NoError(t, err)
+
+	assert.Equal(t, pulumi.Bool(true), args.UseOidc)
+	assert.NotNil(t, args.OidcToken)
+	assert.Nil(t, args.ClientSecret)
+}
+
+func TestBuildProviderArgs_WebIdentity_MissingToken_Errors(t *testing.T) {
+	cfg := &azureprovider.AzureProviderConfig{
+		ClientId:       "11111111-1111-1111-1111-111111111111",
+		TenantId:       "22222222-2222-2222-2222-222222222222",
+		SubscriptionId: "33333333-3333-3333-3333-333333333333",
+		WebIdentity:    &azureprovider.AzureWebIdentityProviderConfig{},
+	}
+
+	_, err := buildProviderArgs(cfg)
+	assert.Error(t, err)
+}
+
+func TestProviderResourceName(t *testing.T) {
+	// State continuity: the base name must stay "azure".
+	assert.Equal(t, "azure", ProviderResourceName(nil))
+	assert.Equal(t, "azure-replica", ProviderResourceName([]string{"replica"}))
+	assert.Equal(t, "azure-dns-zone", ProviderResourceName([]string{"dns", "zone"}))
+}


### PR DESCRIPTION
## Summary

Adds keyless (OIDC web-identity) authentication support to the Azure pulumi providers, mirroring the AWS keyless stack. A caller (e.g. the Planton runner) can now supply a short-lived OIDC JWT instead of a static client secret; the pulumi Azure provider plugins exchange it via Azure Workload Identity Federation (the AAD client-assertion flow).

## Changes

### Proto: `apis/dev/planton/provider/azure/provider.proto`

- New `AzureWebIdentityProviderConfig { web_identity_token }` message and `web_identity = 5` field on `AzureProviderConfig`.
- `client_secret` relaxed from `required` to `IGNORE_IF_ZERO_VALUE` so keyless configs validate (same shape as the AWS `access_key_id`/`secret_access_key` relaxation). `client_id`/`tenant_id`/`subscription_id` stay required — keyless reuses all three.
- Regenerated Go stubs.

### Two new shared provider builders (none existed for Azure)

- `pkg/iac/pulumi/pulumimodule/provider/azure/pulumiazureprovider` (pulumi-azure classic v6)
- `pkg/iac/pulumi/pulumimodule/provider/azure/pulumiazurenativeprovider` (pulumi-azure-native v3)

Both mirror the AWS builders' shape (`Get` + a pure, unit-testable `buildProviderArgs`) and dispatch on the populated config fields: `web_identity` → inline `UseOidc` + `OidcToken`; `client_secret` → static service-principal credentials; neither → ambient credential chain. Provider resource name is pinned to `"azure"` (the name every existing module already uses) so adoption never triggers a provider replacement in live stacks.

Unlike AWS there is **no builder-side token exchange**: the pulumi Azure providers consume the inline token natively (the AWS builders only exchange in-process to work around upstream pulumi-aws#6228). Zero new dependencies.

**Security note:** azure-native v3 `NewProvider` does not auto-secret-wrap `OidcToken` (classic v6 does), so the native builder wraps it with `pulumi.ToSecret` to keep the minted JWT out of plaintext Pulumi state. Covered by tests.

### Walking-skeleton adoption

`azureresourcegroup` now builds its provider through the shared classic builder instead of its inline `azure.NewProvider`.

## Scope note (important)

Keyless auth works **only on modules adopted onto the shared builders** — for now, `azureresourcegroup`. The remaining Azure modules still construct their provider inline, ignore `web_identity`, and would read an empty `client_secret`; migrating them is a deliberate follow-up. Do not assume Azure-wide keyless support from this PR.

## Validation

- `go test` on both builder packages (table-driven suites: ambient, static, keyless, keyless-precedence, empty-token error, pinned resource name, native secret-wrap assertion) — pass.
- `bazel test //pkg/iac/pulumi/pulumimodule/provider/azure/...` — 2/2 pass.
- `make protos` (buf lint + stub regeneration + Java stub compile gate) — pass.
- Targeted `go build` + `go vet` on the builders and the adopted `azureresourcegroup` module; `bazel build` on the module target — pass.
- Not validated here: a live Azure token exchange (requires a sandbox subscription with a federated identity credential); the builder dispatch logic is fully unit-tested.

## AI disclosure

Authored with an AI coding agent; reviewed and validated via the checks above.
