### PR TITLE
docs: reposition README download-first 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,129 +1,133 @@
-# Planton
-
-> **Deploy anywhere with one workflow.** Write declarative YAML once, deploy to AWS, GCP, Azure, or Kubernetes with the same CLI and consistent experience.
-
 <p align="center">
-  <img src="site/public/icon.png" alt="planton-logo"> <img src="site/public/text-logo.svg" alt="planton-text-logo">
+  <img src="site/public/icon.png" alt="Planton logo" width="72">
 </p>
 
-## What is Planton?
+# Planton
 
-An open-source multi-cloud deployment framework that brings Kubernetes-style consistency to infrastructure deployments everywhere. No vendor lock-in, no artificial abstractions—just provider-specific configurations with a unified structure and workflow.
+> **Deploy real infrastructure to your own cloud — without writing Terraform.**
 
-<!-- AI-AGENT NOTE: The deployment component count below MUST be verified against the authoritative source:
-     apis/dev/planton/shared/cloudresourcekind/cloud_resource_kind.proto
-     Count only non-test, non-unspecified enum values in the CloudResourceKind enum. -->
+Planton is a free desktop app and CLI you download and open. It finds the cloud
+you're already signed into; pick a stack and fill a short form, or
+`planton apply -f` a manifest from your terminal — and watch it deploy, with
+clean, auditable infrastructure-as-code running underneath. No account. No
+connections. No ceremony.
 
-**360+ deployment components** across **17 cloud providers** — AWS, GCP, Azure, Kubernetes, OCI, Alibaba Cloud, Hetzner Cloud, DigitalOcean, Cloudflare, Civo, Scaleway, OpenStack, Confluent, Snowflake, Auth0, MongoDB Atlas, and OpenFGA.
+<p align="center">
+  <b><a href="https://planton.app/download">Download Planton</a></b>
+  &nbsp;·&nbsp; Free forever, including for commercial use
+  &nbsp;·&nbsp; Runs on macOS · Linux · Windows
+</p>
 
-**[Documentation](https://planton.dev)** · **[Component Catalog](https://planton.dev/docs/catalog)** · **[Getting Started](https://planton.dev/docs/getting-started)**
-
----
-
-## Why Planton?
-
-- **One structure, any cloud** — Kubernetes Resource Model (apiVersion/kind/metadata/spec) for all deployments
-- **Validate before deploy** — Protocol Buffer validations catch errors in seconds, not minutes
-- **Zero abstraction** — Provider-specific configs preserve cloud capabilities; consistent experience across all
-- **Choose your IaC** — Built-in Pulumi and Terraform/OpenTofu modules with feature parity
-- **Build on top** — Auto-generated SDKs in Go, Python, TypeScript, Java from Protocol Buffer definitions
+**[Website](https://planton.app)** · **[Getting Started](https://planton.app/docs/getting-started)** · **[Documentation](https://planton.app/docs)**
 
 ---
 
-## Quick Start
+## How it works
 
-### 1. Install the CLI
+You never start from a blank Terraform file. Planton runs **proven, pre-built
+infrastructure-as-code modules** — built for secure, well-architected,
+cost-efficient defaults — against your own cloud account, with real state and
+history. Create like a console: pick a stack, fill a short form. Manage like
+Kubernetes: `planton apply -f` deploys a single component, and
+`planton chart install` stands up a whole environment — the `kubectl apply` and
+`helm install` gestures, freed from Kubernetes and extended to every cloud.
+
+Whichever way you deploy, it's real infrastructure-as-code the whole way down —
+stored, versioned, every change a diff. On your own cloud. Nothing to lock you
+in.
+
+## What's in this repository
+
+This repo holds the **open building blocks** that power Planton, all under
+Apache-2.0. Audit them, fork them, or take your configuration and run it
+yourself.
+
+<!-- AI-AGENT NOTE: The component and provider counts below MUST be verified against
+     the authoritative source: apis/dev/planton/shared/cloudresourcekind/cloud_resource_kind.proto
+     (count non-test `(kind_meta)` annotations and distinct providers). The chart
+     count MUST be verified against `charts/*/*/Chart.yaml`. Never re-type a stale number. -->
+
+- **[`apis/`](apis/dev/planton/provider)** — **400+ deployment components**
+  across **17 cloud providers** (AWS, GCP, Azure, Kubernetes, OCI, Alibaba
+  Cloud, Hetzner Cloud, DigitalOcean, Cloudflare, Civo, Scaleway, OpenStack,
+  Confluent, Snowflake, Auth0, MongoDB Atlas, and OpenFGA). Each component is a
+  Protocol Buffer definition in the Kubernetes Resource Model shape
+  (`apiVersion`/`kind`/`metadata`/`spec`) with field-level validations and
+  auto-generated SDKs in Go, Python, TypeScript, and Java.
+- **[`charts/`](charts)** — **49 ready-made infra charts**: whole environments
+  (network + compute + data + DNS) composed from the components above and
+  installed in one command — the Helm-chart idea, for cloud infrastructure.
+- **[`cmd/planton`](cmd/planton)** — the open-source CLI and IaC engine that
+  validates manifests and executes the Pulumi and OpenTofu/Terraform modules
+  that ship with every component.
+- **[`site/`](site)** — the [planton.app](https://planton.app) website and
+  documentation.
+
+## The CLI
+
+The desktop app is the product; the CLI is its companion — the same deploys,
+from your shell, driving the same engine.
 
 ```bash
 brew install plantonhq/tap/planton
 ```
 
-### 2. Create a YAML Manifest
-
-Example: Deploy PostgreSQL to Kubernetes using the [KubernetesPostgres](https://buf.build/planton/planton/file/main:dev/planton/provider/kubernetes/kubernetespostgres/v1/spec.proto) deployment component.
+Write a manifest in the shape you already know:
 
 ```yaml
 apiVersion: kubernetes.planton.dev/v1
 kind: KubernetesPostgres
 metadata:
   name: my-first-postgres
-  labels:
-    planton.dev/provisioner: pulumi
-    pulumi.planton.dev/organization: organization
-    pulumi.planton.dev/project: getting-started
-    pulumi.planton.dev/stack.name: dev
 spec:
   namespace:
     value: my-first-postgres
   createNamespace: true
   container:
     replicas: 1
-    resources:
-      requests:
-        cpu: 50m
-        memory: 100Mi
-      limits:
-        cpu: 500m
-        memory: 512Mi
     diskSize: 1Gi
 ```
 
-You can create similar manifests for [AWS VPC](https://github.com/plantonhq/planton/tree/main/apis/dev/planton/provider/aws/awsvpc/v1), [GKE Cluster](https://github.com/plantonhq/planton/tree/main/apis/dev/planton/provider/gcp/gcpgkecluster/v1), [Kafka on Kubernetes](https://github.com/plantonhq/planton/tree/main/apis/dev/planton/provider/kubernetes/kuberneteskafka/v1), and [many more](https://github.com/plantonhq/planton/tree/main/apis/dev/planton/provider).
-
-### 3. Deploy
+Then deploy it:
 
 ```bash
-# Unified command (auto-detects provisioner from manifest labels)
 planton apply -f postgres.yaml
-
-# Or use IaC-specific commands directly
-planton pulumi up -f postgres.yaml
-planton tofu apply -f postgres.yaml
 ```
 
----
+Validation catches mistakes in seconds — before anything touches your cloud —
+and the deploy streams live output from the underlying IaC module. See the
+[Getting Started guide](https://planton.app/docs/getting-started) and the
+[CLI reference](https://planton.app/docs/cli/cli-reference).
 
-## CLI Overview
+## Licensing
 
-```
-planton
-├── apply / destroy / plan      Unified commands (provisioner auto-detected)
-├── pulumi                      Pulumi-specific commands (init, preview, up, destroy, refresh)
-├── tofu                        OpenTofu commands (init, plan, apply, destroy, refresh)
-├── terraform                   Terraform commands (init, plan, apply, destroy, refresh)
-├── validate                    Validate manifest against protobuf schema
-├── pull / checkout             Module management
-├── config                      CLI configuration
-└── version / upgrade           Version management
-```
-
-See the full [CLI Reference](https://planton.dev/docs/cli/cli-reference) for all commands, flags, and options.
-
----
-
-## Learn More
-
-- **[Getting Started Guide](https://planton.dev/docs/getting-started)** — Your first deployment in 10 minutes
-- **[Component Catalog](https://planton.dev/docs/catalog)** — Browse 360+ deployment components across 17 providers
-- **[Architecture](https://planton.dev/docs/concepts/architecture)** — How Protocol Buffers, IaC modules, and CLI work together
-- **[Planton](https://planton.ai)** — Commercial SaaS platform with UI, CI/CD, and team features
-
----
+Planton the app is **free**, including for commercial use. The building blocks
+that power it — the infrastructure components, the charts, and the CLI — are
+**open source under [Apache-2.0](LICENSE)**: audit them, fork them, or take
+your configuration and run it yourself. No lock-in.
 
 ## Contributing
 
-Visit [CONTRIBUTING.md](CONTRIBUTING.md) for information on building Planton from source or contributing improvements.
-
-Also, refer to the [Contributor Guide](https://planton.dev/docs/contributing) for detailed information about becoming a contributor to Planton.
-
-## License
-
-Planton is released under the [Apache 2.0 license](LICENSE). You are free to use, modify, and distribute this software in accordance with the license terms.
+Visit [CONTRIBUTING.md](CONTRIBUTING.md) for information on building Planton
+from source, and the [Contributor Guide](https://planton.app/docs/contributing)
+for details about becoming a contributor.
 
 ## Acknowledgments
 
-- **Brian Grant & Kubernetes API team** for their foundational work on the Kubernetes Resource Model.
-- The **[Protobuf Team](https://protobuf.dev/)** for laying the foundation for a powerful language neutral contract definition language.
-- The **[Buf](https://github.com/bufbuild/buf) Team** for their Protobuf tooling—including BSR Docs, BSR SDKs, and ProtoValidate — which collectively democratized protobuf adoption and made this project possible.
-- The **[Pulumi](https://github.com/pulumi/pulumi)** team for providing a powerful infrastructure as code platform that enables multi-language support.
-- The **[spf13/cobra](https://github.com/spf13/cobra)** team for making building command line tools a bliss.
+- **Brian Grant & the Kubernetes API team** for their foundational work on the
+  Kubernetes Resource Model.
+- The **[Protobuf Team](https://protobuf.dev/)** for laying the foundation for
+  a powerful language-neutral contract definition language.
+- The **[Buf](https://github.com/bufbuild/buf) Team** for their Protobuf
+  tooling — including BSR Docs, BSR SDKs, and ProtoValidate — which
+  collectively democratized protobuf adoption and made this project possible.
+- The **[Pulumi](https://github.com/pulumi/pulumi)** team for providing a
+  powerful infrastructure-as-code platform that enables multi-language support.
+- The **[spf13/cobra](https://github.com/spf13/cobra)** team for making
+  building command line tools a bliss.
+
+---
+
+<p align="center">
+  Built by <a href="https://planton.ai">Planton</a>
+</p>

--- a/charts/aws/container-app/README.md
+++ b/charts/aws/container-app/README.md
@@ -100,4 +100,4 @@ memory: "12288"
 
 ---
 
-© 2025 Planton. All rights reserved.
+© Planton. Licensed under [Apache-2.0](../../../LICENSE).

--- a/charts/aws/ecs-environment/README.md
+++ b/charts/aws/ecs-environment/README.md
@@ -76,4 +76,4 @@ Booleans are shown as **unquoted YAML booleans** (`true` /`false`) to avoid stri
 
 ---
 
-© 2025 Planton. All rights reserved.
+© Planton. Licensed under [Apache-2.0](../../../LICENSE).

--- a/charts/aws/eks-environment/README.md
+++ b/charts/aws/eks-environment/README.md
@@ -13,4 +13,4 @@ This chart provisions a **complete, production‑ready Kubernetes environment on
 
 Edit **values.yaml** to tailor the deployment; each `*Enabled` boolean cleanly removes its add‑on.
 
-© 2025 Planton. All rights reserved.
+© Planton. Licensed under [Apache-2.0](../../../LICENSE).

--- a/charts/aws/kafka-streaming/README.md
+++ b/charts/aws/kafka-streaming/README.md
@@ -90,4 +90,4 @@ ebs_volume_size_gib: "500"
 
 ---
 
-© 2025 Planton. All rights reserved.
+© Planton. Licensed under [Apache-2.0](../../../LICENSE).

--- a/charts/aws/microservices-backend/README.md
+++ b/charts/aws/microservices-backend/README.md
@@ -130,4 +130,4 @@ httpsEnabled: false
 
 ---
 
-© 2025 Planton. All rights reserved.
+© Planton. Licensed under [Apache-2.0](../../../LICENSE).

--- a/charts/aws/ml-workbench/README.md
+++ b/charts/aws/ml-workbench/README.md
@@ -91,4 +91,4 @@ auth_mode: SSO
 
 ---
 
-© 2025 Planton. All rights reserved.
+© Planton. Licensed under [Apache-2.0](../../../LICENSE).

--- a/charts/aws/pulumi-backend/README.md
+++ b/charts/aws/pulumi-backend/README.md
@@ -46,4 +46,4 @@ requirements. Individual configurations may be modified directly in your AWS acc
 
 ---
 
-© 2025 Planton. All rights reserved.
+© Planton. Licensed under [Apache-2.0](../../../LICENSE).

--- a/charts/aws/terraform-backend/README.md
+++ b/charts/aws/terraform-backend/README.md
@@ -54,4 +54,4 @@ Individual configurations may be modified directly in your AWS account or throug
 
 ---
 
-© 2025 Planton. All rights reserved.
+© Planton. Licensed under [Apache-2.0](../../../LICENSE).

--- a/charts/civo/civo-kubernetes-environment/README.md
+++ b/charts/civo/civo-kubernetes-environment/README.md
@@ -85,5 +85,5 @@ Setting a flag to `false` omits the corresponding manifest from the final render
 
 ---
 
-© 2025 Planton. All rights reserved.
+© Planton. Licensed under [Apache-2.0](../../../LICENSE).
 

--- a/charts/gcp/cloud-run-environment/README.md
+++ b/charts/gcp/cloud-run-environment/README.md
@@ -297,4 +297,4 @@ When `dockerRepoEnabled: true`, an Artifact Registry Docker repository is create
 
 ---
 
-© 2025 Planton. All rights reserved.
+© Planton. Licensed under [Apache-2.0](../../../LICENSE).

--- a/charts/gcp/gke-environment/README.md
+++ b/charts/gcp/gke-environment/README.md
@@ -123,4 +123,4 @@ Booleans are shown as **unquoted YAML booleans** (`true`/`false`) to avoid strin
 
 ---
 
-© 2025 Planton. All rights reserved.
+© Planton. Licensed under [Apache-2.0](../../../LICENSE).

--- a/charts/openstack/developer-environment/README.md
+++ b/charts/openstack/developer-environment/README.md
@@ -105,4 +105,4 @@ and Subnet, the Instance waits for the Port and Keypair, and so on.
 
 ---
 
-(c) 2026 Planton. All rights reserved.
+© Planton. Licensed under [Apache-2.0](../../../LICENSE).

--- a/charts/openstack/project-landing-zone/README.md
+++ b/charts/openstack/project-landing-zone/README.md
@@ -101,4 +101,4 @@ openstack user list        # find the user ID
 
 ---
 
-(c) 2026 Planton. All rights reserved.
+© Planton. Licensed under [Apache-2.0](../../../LICENSE).

--- a/charts/scaleway/database-stack/README.md
+++ b/charts/scaleway/database-stack/README.md
@@ -148,4 +148,4 @@ Kubernetes cluster, enabling pods to connect to databases over private IPs.
 
 ---
 
-(c) 2025 Planton. All rights reserved.
+© Planton. Licensed under [Apache-2.0](../../../LICENSE).

--- a/charts/scaleway/kapsule-environment/README.md
+++ b/charts/scaleway/kapsule-environment/README.md
@@ -139,4 +139,4 @@ Setting a flag to `false` omits the corresponding manifest from the final render
 
 ---
 
-(c) 2025 Planton. All rights reserved.
+© Planton. Licensed under [Apache-2.0](../../../LICENSE).

--- a/charts/scaleway/serverless-environment/README.md
+++ b/charts/scaleway/serverless-environment/README.md
@@ -120,4 +120,4 @@ to the container's native Scaleway endpoint.
 
 ---
 
-(c) 2025 Planton. All rights reserved.
+© Planton. Licensed under [Apache-2.0](../../../LICENSE).


### PR DESCRIPTION
## Summary
- Rewrites the repository README to the desktop-first positioning already live on [planton.app](https://planton.app): the hero leads with the free desktop app ("Deploy real infrastructure to your own cloud — without writing Terraform"), the CLI is presented as its companion, and the primary CTA is **Download Planton** → planton.app/download.
- All docs links now point at the live `planton.app` routes (the previous `planton.dev` links 404). Counts re-derived from source: 400+ components / 17 providers (from `cloud_resource_kind.proto`), 49 charts (from `charts/*/*/Chart.yaml`); the AI-agent count-verification note is retained and extended.
- Aligns 16 chart README footers with the repository's Apache-2.0 license: residual "© Planton. All rights reserved." lines (which contradicted the root LICENSE) are replaced with an explicit Apache-2.0 statement, so the README's licensing claim ("components, charts, and CLI are open source under Apache-2.0") is true.

## Test plan
- [x] All relative links in the README resolve (`apis/dev/planton/provider`, `charts/`, `cmd/planton`, `site/`, `LICENSE`, `CONTRIBUTING.md`)
- [x] All external links verified live (planton.app routes return 200)
- [x] No "all rights reserved" remains under `charts/`