### PR TITLE
feat(site): wire /download to real desktop installers 🤖🤖🤖

### DIFF
--- a/site/src/app/download/page.tsx
+++ b/site/src/app/download/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { Download } from "lucide-react";
 import { SiteHeader, SiteFooter } from "@/components/chrome";
 import { Button } from "@/components/ui/button";
-import { OPERATING_SYSTEMS, RELEASES_URL } from "@/site";
+import { DOWNLOADS, LINUX_DEB_URL, RELEASES_URL } from "@/site";
 
 export const metadata: Metadata = {
   title: "Download",
@@ -30,22 +30,50 @@ export default function DownloadPage() {
             Desktop App
           </h2>
           <div className="mt-5 grid gap-3 sm:grid-cols-3">
-            {OPERATING_SYSTEMS.map((os) => (
+            {DOWNLOADS.map(({ os, href, note }) => (
               <Button
                 key={os}
                 asChild
                 variant="secondary"
-                className="h-auto justify-start gap-2 rounded-lg border border-border py-3"
+                className="h-auto flex-col items-start gap-1 rounded-lg border border-border px-4 py-3"
               >
-                <Link href={RELEASES_URL} target="_blank" rel="noreferrer">
-                  <Download className="size-4" />
-                  <span>Download for {os}</span>
-                </Link>
+                <a href={href}>
+                  <span className="flex items-center gap-2">
+                    <Download className="size-4" />
+                    <span>Download for {os}</span>
+                  </span>
+                  <span className="text-xs font-normal text-muted-foreground">
+                    {note}
+                  </span>
+                </a>
               </Button>
             ))}
           </div>
+          <p className="mt-4 text-sm text-muted-foreground">
+            On Debian or Ubuntu, you can also install the{" "}
+            <a href={LINUX_DEB_URL} className="underline underline-offset-4">
+              .deb package
+            </a>
+            . On macOS, if you see a warning on first open, right-click the app
+            and choose Open.
+          </p>
         </section>
 
+        <section className="mt-12">
+          <p className="text-sm text-muted-foreground">
+            Looking for the open building blocks — components, charts, and the
+            CLI source? They live on{" "}
+            <Link
+              href={RELEASES_URL}
+              target="_blank"
+              rel="noreferrer"
+              className="underline underline-offset-4"
+            >
+              GitHub Releases
+            </Link>
+            .
+          </p>
+        </section>
       </main>
       <SiteFooter />
     </>

--- a/site/src/site/download.ts
+++ b/site/src/site/download.ts
@@ -1,7 +1,11 @@
 /**
  * Download configuration — the single source for the primary CTA target and the
- * platforms the desktop app targets. Wiring the target to a real artifact/CDN is
- * a tracked "make it real" follow-up.
+ * direct installer downloads.
+ *
+ * The installer URLs point at the `latest` channel aliases on the Planton
+ * downloads CDN. The desktop release pipeline republishes these aliases on
+ * every stable release, so the URLs are version-free and always serve the
+ * current installer.
  *
  * Note: the marketing surface intentionally does NOT teach CLI install — the
  * desktop launch experience owns CLI setup. So there are no CLI install commands
@@ -13,3 +17,28 @@ export const DOWNLOAD_HREF = "/download";
 
 /** Platforms the desktop app targets, shown next to the download CTA. */
 export const OPERATING_SYSTEMS = ["macOS", "Linux", "Windows"] as const;
+
+/** Base URL of the stable-channel installer aliases on the downloads CDN. */
+export const DOWNLOADS_BASE = "https://downloads.planton.app/desktop/latest";
+
+/** Direct installer downloads, one per platform. */
+export const DOWNLOADS = [
+  {
+    os: "macOS",
+    href: `${DOWNLOADS_BASE}/planton-desktop-universal-macos.dmg`,
+    note: "Universal — Apple Silicon + Intel",
+  },
+  {
+    os: "Linux",
+    href: `${DOWNLOADS_BASE}/planton-desktop-linux-amd64.AppImage`,
+    note: "AppImage — x86_64",
+  },
+  {
+    os: "Windows",
+    href: `${DOWNLOADS_BASE}/planton-desktop-windows-x64-setup.exe`,
+    note: "Installer — x64",
+  },
+] as const;
+
+/** Debian/Ubuntu package, offered as a secondary Linux option. */
+export const LINUX_DEB_URL = `${DOWNLOADS_BASE}/planton-desktop-linux-amd64.deb`;


### PR DESCRIPTION
## Summary
- Points the /download page's per-OS buttons at the version-free installer aliases on the downloads CDN (`downloads.planton.app/desktop/latest/...`), replacing the GitHub Releases link (which carries CLI tarballs and charts, not the desktop app).
- Adds a secondary `.deb` option for Debian/Ubuntu and an honest one-line note about the macOS first-open warning.
- Keeps GitHub Releases as a secondary link for the open building blocks (components, charts, CLI source).

The `latest` aliases are seeded with the current stable installers and are republished by the desktop release pipeline on every stable release.

## Test plan
- [x] `yarn typecheck`, `yarn lint` (0 errors; 3 pre-existing warnings in an untouched script), `yarn build` green
- [x] Built `out/download.html` carries the four CDN URLs
- [x] All four alias URLs verified serving (HTTP 200)