### PR TITLE
docs(site): one-story pass over the docs framing 🤖🤖🤖

### DIFF
--- a/site/public/docs/cli/configuration.md
+++ b/site/public/docs/cli/configuration.md
@@ -133,7 +133,7 @@ planton -v
 planton --version
 ```
 
-The command prints the current version, fetches the latest available version from GitHub releases, and indicates whether an update is available. If a newer version exists, it suggests running `planton upgrade`.
+The command prints the current version, checks for the latest available version, and indicates whether an update is available. If a newer version exists, it suggests running `planton upgrade`.
 
 ## What's Next
 

--- a/site/public/docs/cli/index.md
+++ b/site/public/docs/cli/index.md
@@ -7,19 +7,17 @@ order: 20
 
 # CLI
 
-The `planton` CLI is a single binary that handles the full deployment lifecycle: manifest loading, validation, module resolution, provisioner execution, and state management across Pulumi, OpenTofu, and Terraform.
+The `planton` CLI is the desktop app's companion for the terminal — it drives the same engine and handles the full deployment lifecycle: manifest loading, validation, module resolution, provisioner execution, and state management across Pulumi, OpenTofu, and Terraform.
 
 ## Installation
 
 ```bash
-# macOS (Homebrew)
+# Homebrew
 brew install plantonhq/tap/planton
 
 # Verify
 planton version
 ```
-
-For other platforms, download the binary from [GitHub Releases](https://github.com/plantonhq/planton/releases).
 
 You also need at least one IaC engine installed:
 
@@ -95,7 +93,7 @@ You can let the CLI detect the provisioner automatically from the manifest's `pl
 
 - **[Terraform Commands](./terraform-commands)** — Terraform-specific subcommands: `init`, `plan`, `apply`, `destroy`, `refresh`. Shares the same HCL modules and execution engine as OpenTofu.
 
-- **[Module Management](./module-management)** — Module resolution chain, the staging area, version pinning with `checkout` and `pull`, and CLI version management with `upgrade` and `downgrade`.
+- **[Module Management](./module-management)** — Module resolution chain, the staging area, version pinning with `checkout` and `pull`, and keeping the CLI up to date.
 
 - **[Configuration & Utilities](./configuration)** — CLI configuration (`config set/get/list`), manifest validation (`validate`), manifest loading (`load`), and version checking.
 

--- a/site/public/docs/cli/module-management.md
+++ b/site/public/docs/cli/module-management.md
@@ -97,9 +97,9 @@ planton tofu apply --manifest database.yaml --module-version main
 
 This is useful for testing a specific module version without permanently switching the staging area.
 
-## CLI Version Management
+## Keeping the CLI Up to Date
 
-These commands manage the `planton` CLI binary itself, not the IaC modules.
+These commands manage the `planton` CLI binary itself, not the IaC modules. If you installed via Homebrew, `brew upgrade planton` works too — `planton upgrade` is the built-in equivalent that works everywhere.
 
 ### upgrade
 
@@ -107,7 +107,6 @@ Upgrade the CLI to the latest available version or to a specific version.
 
 ```bash
 planton upgrade
-planton upgrade v0.3.10-cli.20260110.0
 planton upgrade --check
 planton upgrade --force
 ```
@@ -117,22 +116,20 @@ planton upgrade --force
 | `--check` | `-c` | Check for updates without installing |
 | `--force` | `-f` | Force upgrade even if already on the latest or specified version |
 
-The binary is downloaded directly from GitHub releases and replaces the currently running executable.
-
 ### downgrade
 
 Install a specific previous version of the CLI.
 
 ```bash
-planton downgrade v0.3.5-cli.20260108.0
-planton downgrade v0.3.5-cli.20260108.0 --force
+planton downgrade v0.3.1
+planton downgrade v0.3.1 --force
 ```
 
 | Flag | Short | Description |
 |------|-------|-------------|
 | `--force` | `-f` | Force install even if already on the specified version |
 
-The version argument is required. The binary is downloaded directly from GitHub releases.
+The version argument is required.
 
 ## Workspace Isolation
 

--- a/site/public/docs/concepts/index.md
+++ b/site/public/docs/concepts/index.md
@@ -1,15 +1,15 @@
 ---
 title: "Concepts"
-description: "The core ideas behind Planton: how a multi-cloud deployment framework brings Kubernetes-style consistency to infrastructure across 17 cloud providers"
+description: "The core ideas behind Planton: how Kubernetes-style consistency extends to infrastructure across 17 cloud providers"
 icon: "lightbulb"
 order: 10
 ---
 
 # Concepts
 
-Planton is a multi-cloud deployment framework that brings Kubernetes-style consistency to infrastructure provisioning across any cloud provider. It is built on three foundational ideas: Protocol Buffer APIs define the resource model, dual IaC engines (Pulumi and OpenTofu/Terraform) implement the deployments, and a Go CLI orchestrates the entire workflow.
+Planton brings Kubernetes-style consistency to infrastructure provisioning across any cloud provider. Whether you deploy from the desktop app or the CLI, the same engine runs underneath — built on three foundational ideas: Protocol Buffer APIs define the resource model, dual IaC engines (Pulumi and OpenTofu/Terraform) implement the deployments, and the engine orchestrates the entire workflow.
 
-This section explains the core concepts that make the framework work.
+This section explains the core concepts that make Planton work.
 
 ## The Problem
 
@@ -23,7 +23,7 @@ Planton takes a different path: consistency of structure and workflow, not abstr
 
 Every resource across every provider follows the same manifest format (the Kubernetes Resource Model), uses the same validation framework (Protocol Buffers with buf-validate), is deployed with the same CLI commands, and is managed through the same module and state systems. But the spec -- the actual configuration surface -- is provider-specific. An `AwsS3Bucket` exposes the full S3 feature set. A `GcpGcsBucket` exposes the full GCS feature set. Neither pretends to be the other.
 
-The result: you learn one set of tools and one workflow pattern, then apply it to 360+ deployment components across 17 cloud providers. The learning curve is the framework itself, not each provider's toolchain.
+The result: you learn one set of tools and one workflow pattern, then apply it to 400+ deployment components across 17 cloud providers. The learning curve is one workflow, not each provider's toolchain.
 
 ## Key Concepts
 

--- a/site/public/docs/index.md
+++ b/site/public/docs/index.md
@@ -1,21 +1,21 @@
 ---
 title: "Documentation"
-description: "Comprehensive guides for Planton - the open-source multi-cloud infrastructure framework"
+description: "Comprehensive guides for Planton - the free desktop app and CLI for your cloud infrastructure"
 icon: "book"
 order: 1
 ---
 
 # Welcome to Planton Documentation
 
-Planton is an open-source multi-cloud infrastructure framework that lets you author KRM-style YAML manifests once, validate them with Protobuf + Buf, and deploy with Pulumi or OpenTofu.
+Planton is a free desktop app and CLI for your cloud infrastructure. You download it, open it, and deploy to your own cloud — with clean, auditable infrastructure-as-code running underneath. Manifests follow the Kubernetes Resource Model, are validated with Protobuf + Buf, and deploy through proven Pulumi or OpenTofu modules.
 
 ## Getting Started
 
-New to Planton? Start here:
+New to Planton? Start with the **[Getting Started guide](/docs/getting-started)**:
 
-- Install the CLI via Homebrew
-- Validate your first manifest
-- Deploy to your cloud provider or Kubernetes cluster
+- Download the desktop app and deploy from a short form
+- Or install the companion CLI via Homebrew
+- Validate a manifest and deploy to your cloud provider or Kubernetes cluster
 
 ## CLI Reference
 
@@ -153,7 +153,7 @@ Browse deployment components by cloud provider in the [Catalog](/docs/catalog):
 - **One Model, Many Clouds**: Single API structure across AWS, GCP, Azure, and Kubernetes
 - **Validation First**: Buf ProtoValidate catches errors before deployment
 - **Battle-Tested Modules**: Curated Pulumi and OpenTofu modules
-- **CLI-First Workflow**: Developer-grade CLI for all operations
+- **App and Terminal, One Engine**: Deploy from the desktop app's forms or the companion CLI — both drive the same engine
 - **Security & Governance**: Provider credentials as stack inputs, consistent labeling
 
 ## Quick Example

--- a/site/public/docs/troubleshooting.md
+++ b/site/public/docs/troubleshooting.md
@@ -30,7 +30,7 @@ Solutions to common problems you might encounter using Planton.
 # Right: AwsS3Bucket
 
 # 2. Verify kind exists in catalog
-# Browse: https://planton.dev/docs/catalog
+# Browse: /docs/catalog
 
 # 3. Check available kinds in your CLI version
 # (List is shown in error message)

--- a/site/public/docs/tutorials/index.md
+++ b/site/public/docs/tutorials/index.md
@@ -13,7 +13,7 @@ If you are looking for focused reference material on a specific topic (credentia
 
 ## Before You Start
 
-All tutorials assume you have the Planton CLI installed. If you have not set it up yet, start with [Getting Started](../getting-started).
+All tutorials use the Planton CLI; everything shown can also be done from the desktop app. If you have not set either up yet, start with [Getting Started](../getting-started).
 
 ## Tutorials
 


### PR DESCRIPTION
## Summary
- Aligns the remaining docs with the positioning already live on the landing page, getting-started, and desktop-and-cli concept pages: Planton is a free desktop app with the CLI as its terminal companion, both driving the same engine. Rewrites the "open-source multi-cloud infrastructure framework" framing in the docs index and concepts index (including the stale "360+" count → "400+").
- CLI docs: positions the CLI as the companion on the section index, drops the GitHub-Releases alt-install line (brew is the canonical install), reframes "CLI Version Management" as "Keeping the CLI Up to Date" (keeps `upgrade`/`downgrade` documented, drops distribution mechanics, mentions `brew upgrade`).
- Small fixes: absolute `planton.dev/docs/catalog` URL → relative `/docs/catalog` in troubleshooting; tutorials index acknowledges the desktop app.

## Test plan
- [x] `yarn typecheck` and `yarn build` green
- [x] No "multi-cloud framework" / "CLI-First" framing remains outside the catalog