### PR TITLE
fix(auth0connection): default advanced password options off (free-tier 403 + Pulumi parity)

### DIFF
--- a/_changelog/2026-07/2026-07-03-152700-auth0connection-advanced-password-opt-in.md
+++ b/_changelog/2026-07/2026-07-03-152700-auth0connection-advanced-password-opt-in.md
@@ -1,0 +1,80 @@
+# Auth0Connection: Advanced Password Options Opt-In (Free-Tier 403 Fix + Engine Parity)
+
+**Date**: July 3, 2026
+**Type**: Bug Fix
+**Components**: API Definitions, Terraform, Documentation
+
+## Summary
+
+The `Auth0Connection` Terraform module deployed with three "advanced password options" (`password_history_size`, `password_no_personal_info`, `password_dictionary`) enabled by default. Those features require Auth0's paid `password-advanced-options` entitlement, so on a free/lower-tier tenant Auth0 rejected the deploy with a `403 Forbidden: Subscription missing entitlement: password-advanced-options`. This broke the `e2e-auth0` pipeline (`TestAuth0Connection_Terraform/minimal`). The Pulumi module never applied these defaults, so the two engines also diverged. This change flips those three defaults to disabled in Terraform, bringing it to parity with Pulumi and letting the component deploy on any Auth0 plan.
+
+## Problem Statement / Motivation
+
+The Terraform variable schema filled in defaults for the advanced password options via `optional(...)`. When a manifest omitted `database_options` (or these specific fields), Terraform substituted enabled values *before* the `locals.tf` `coalesce` ran, so the module always sent them to Auth0.
+
+### Pain Points
+
+- **Free-tier tenants 403** - a minimal manifest (no advanced options set) still tried to enable them, and Auth0 rejected the whole `auth0_connection` deploy.
+- **Silent CI breakage** - `e2e-auth0`'s `TestAuth0Connection_Terraform/minimal` failed on any tenant lacking the paid entitlement.
+- **Terraform/Pulumi divergence** - the Pulumi module passed the raw spec (proto zero-values), so it left the options off; only Terraform force-enabled them. The same manifest produced different Auth0 configuration depending on the engine.
+- **Misleading docs** - the catalog page, READMEs, and "Sensible Defaults" section advertised `5`/`true`/`true` as safe defaults with no mention of the paid entitlement.
+
+## Root Cause
+
+```mermaid
+flowchart LR
+  tfvars["manifest (field omitted)"] --> varsblock["variables.tf<br/>optional(number, 5)"]
+  varsblock -->|"fills 5"| localsblock["locals.tf<br/>coalesce(5, 0) = 5"]
+  localsblock -->|"still enabled"| tfmod["auth0_connection.options"]
+  tfmod -->|"free-tier tenant"| err["403: missing entitlement<br/>password-advanced-options"]
+```
+
+The real default lived in `variables.tf`'s `optional(...)`, not `locals.tf`. Because `optional()` fills the value before `coalesce` sees it, only changing `locals.tf` would not have fixed the `403` - `variables.tf` had to change too.
+
+## Solution / What's New
+
+Default the three advanced password options to **disabled** in Terraform, matching the Pulumi module's behavior, and document them as opt-in features that require the paid entitlement.
+
+| Field | Old default | New default |
+|-------|-------------|-------------|
+| `password_history_size` | `5` | `0` (disabled) |
+| `password_no_personal_info` | `true` | `false` |
+| `password_dictionary` | `true` | `false` |
+
+```mermaid
+flowchart LR
+  tfvars["manifest (field omitted)"] --> varsblock["variables.tf<br/>optional(number, 0)"]
+  varsblock -->|"fills 0"| localsblock["locals.tf<br/>coalesce(0, 0) = 0"]
+  localsblock -->|"disabled"| tfmod["auth0_connection.options"]
+  tfmod -->|"any tenant"| ok["deploy succeeds"]
+```
+
+Users who *do* have the entitlement can still opt in by setting the fields explicitly in their manifest.
+
+## Implementation Details
+
+- **`apis/dev/planton/provider/auth0/auth0connection/v1/iac/tf/variables.tf`** (primary fix): `password_history_size` -> `optional(number, 0)`, `password_no_personal_info` -> `optional(bool, false)`, `password_dictionary` -> `optional(bool, false)`, each with a comment noting the paid entitlement.
+- **`.../iac/tf/locals.tf`**: `coalesce` fallbacks set to `0`/`false`/`false` (defensive/consistent with `variables.tf`).
+- **`.../spec.proto`**: doc comments updated to state the fields default to disabled and require the paid `password-advanced-options` entitlement.
+- **Pulumi module**: no change - `iac/pulumi/module/locals.go` passes the raw spec (proto zero-values), so the options were already off; this change simply brings Terraform to parity.
+- **Documentation**: `catalog-page.md` default column + entitlement note, `docs/README.md` "Sensible Defaults"/"Password History" caveats, `README.md` and `iac/tf/README.md` example annotations, and a comment in `iac/hack/manifest.yaml`.
+
+## Benefits
+
+- `Auth0Connection` deploys on any Auth0 plan out of the box - no more free-tier `403`.
+- `e2e-auth0` `TestAuth0Connection_Terraform/minimal` passes on the entitlement-less test tenant.
+- Terraform and Pulumi now produce identical Auth0 configuration for the same manifest.
+- Docs accurately describe which options are opt-in and why.
+
+## Impact
+
+- **Behavioral (Terraform only)**: manifests that relied on the implicit `5`/`true`/`true` defaults will now deploy with these options disabled. Anyone who wants them must set the fields explicitly (and hold the paid entitlement). This matches the Pulumi behavior that was already in effect.
+- **No proto wire change**: field numbers and types are unchanged; only defaults and docs changed.
+
+## Related Work
+
+- Follows the CI toolchain image migration ([2026-07-03-143246-common-ci-toolchain-image.md](../2026-07/2026-07-03-143246-common-ci-toolchain-image.md)) whose migrated `e2e-auth0` workflow surfaced this failure.
+
+---
+
+**Status**: ✅ Production Ready

--- a/apis/dev/planton/provider/auth0/auth0connection/v1/README.md
+++ b/apis/dev/planton/provider/auth0/auth0connection/v1/README.md
@@ -48,6 +48,8 @@ spec:
   database_options:
     password_policy: good
     brute_force_protection: true
+    # The three options below are Auth0 "advanced password options" and require a
+    # paid "password-advanced-options" entitlement; omit them on free/lower-tier tenants.
     password_history_size: 5
     password_no_personal_info: true
     password_dictionary: true

--- a/apis/dev/planton/provider/auth0/auth0connection/v1/catalog-page.md
+++ b/apis/dev/planton/provider/auth0/auth0connection/v1/catalog-page.md
@@ -82,10 +82,12 @@ Applicable when `strategy` is `auth0`.
 | `databaseOptions.requiresUsername` | `bool` | `false` | Requires a username in addition to email during signup. |
 | `databaseOptions.disableSignup` | `bool` | `false` | Prevents new user signups. Useful when onboarding is done programmatically. |
 | `databaseOptions.bruteForceProtection` | `bool` | `true` | Blocks login attempts after multiple failures. |
-| `databaseOptions.passwordHistorySize` | `int32` | `5` | Number of previous passwords to check against. Range: 0-24. Set to 0 to disable. |
-| `databaseOptions.passwordNoPersonalInfo` | `bool` | `true` | Prevents passwords containing the user's name, username, or email. |
-| `databaseOptions.passwordDictionary` | `bool` | `true` | Rejects common/weak passwords found in a dictionary. |
+| `databaseOptions.passwordHistorySize` | `int32` | `0` | Number of previous passwords to check against. Range: 0-24. `0` disables it. Requires a paid Auth0 `password-advanced-options` entitlement. |
+| `databaseOptions.passwordNoPersonalInfo` | `bool` | `false` | Prevents passwords containing the user's name, username, or email. Requires a paid Auth0 `password-advanced-options` entitlement. |
+| `databaseOptions.passwordDictionary` | `bool` | `false` | Rejects common/weak passwords found in a dictionary. Requires a paid Auth0 `password-advanced-options` entitlement. |
 | `databaseOptions.mfaEnabled` | `bool` | `false` | Prompts users for a second authentication factor during login. |
+
+> Note: `passwordHistorySize`, `passwordNoPersonalInfo`, and `passwordDictionary` are Auth0's "advanced password options" and require a paid `password-advanced-options` entitlement. They default to disabled so the component works on free/lower-tier tenants; enabling them on a tenant without the entitlement causes Auth0 to reject the deploy with a `403`.
 
 #### Social Options (`socialOptions`)
 
@@ -172,6 +174,8 @@ spec:
   databaseOptions:
     passwordPolicy: excellent
     bruteForceProtection: true
+    # The three advanced password options below require a paid Auth0
+    # "password-advanced-options" entitlement; omit them on free/lower-tier tenants.
     passwordHistorySize: 10
     passwordNoPersonalInfo: true
     passwordDictionary: true

--- a/apis/dev/planton/provider/auth0/auth0connection/v1/docs/README.md
+++ b/apis/dev/planton/provider/auth0/auth0connection/v1/docs/README.md
@@ -227,9 +227,10 @@ Rather than a flat structure with all possible fields, we use strategy-specific 
 All optional fields have production-appropriate defaults:
 - `password_policy: "good"` (not "none")
 - `brute_force_protection: true`
-- `password_dictionary: true`
 
-**Rationale:** Secure by default; users opt-out of security, not opt-in.
+**Rationale:** Secure defaults that work on every Auth0 plan; users opt-out of security, not opt-in.
+
+The three "advanced password options" - `password_history_size`, `password_no_personal_info`, and `password_dictionary` - are an exception: they require Auth0's paid `password-advanced-options` entitlement, so they default to disabled (`0`/`false`). Enabling them on a tenant without the entitlement makes Auth0 reject the deploy with a `403`, so they are opt-in.
 
 #### 3. Validation Rules
 
@@ -273,7 +274,7 @@ Both implementations support identical features:
 1. **Password Policies**: Use "good" or "excellent" for production
 2. **Brute Force**: Always enable brute force protection
 3. **MFA**: Consider MFA for high-security applications
-4. **Password History**: Prevent password reuse (5-10 entries)
+4. **Password History**: Prevent password reuse (5-10 entries) - requires the paid `password-advanced-options` entitlement
 
 ### Operations
 

--- a/apis/dev/planton/provider/auth0/auth0connection/v1/iac/hack/manifest.yaml
+++ b/apis/dev/planton/provider/auth0/auth0connection/v1/iac/hack/manifest.yaml
@@ -23,6 +23,8 @@ spec:
     requires_username: false
     disable_signup: false
     brute_force_protection: true
+    # The three advanced password options below require a paid Auth0
+    # "password-advanced-options" entitlement (the test tenant must have it).
     password_history_size: 5
     password_no_personal_info: true
     password_dictionary: true

--- a/apis/dev/planton/provider/auth0/auth0connection/v1/iac/tf/README.md
+++ b/apis/dev/planton/provider/auth0/auth0connection/v1/iac/tf/README.md
@@ -57,6 +57,8 @@ spec = {
   database_options = {
     password_policy        = "good"
     brute_force_protection = true
+    # password_history_size (>0) needs Auth0's paid "password-advanced-options"
+    # entitlement; leave it 0/unset on free/lower-tier tenants.
     password_history_size  = 5
   }
 }
@@ -144,6 +146,8 @@ spec = {
   database_options = {
     password_policy        = "good"
     brute_force_protection = true
+    # password_history_size (>0) needs Auth0's paid "password-advanced-options"
+    # entitlement; leave it 0/unset on free/lower-tier tenants.
     password_history_size  = 5
   }
 }

--- a/apis/dev/planton/provider/auth0/auth0connection/v1/iac/tf/locals.tf
+++ b/apis/dev/planton/provider/auth0/auth0connection/v1/iac/tf/locals.tf
@@ -31,15 +31,20 @@ locals {
   is_oidc_strategy   = var.spec.strategy == "oidc"
   is_waad_strategy   = var.spec.strategy == "waad"
 
-  # Database options with defaults
+  # Database options with defaults.
+  # password_history_size / password_no_personal_info / password_dictionary are
+  # gated behind Auth0's paid "password-advanced-options" entitlement, so they
+  # default OFF (0/false) - enabling them by default makes the module unusable on
+  # free/lower-tier tenants (Auth0 returns 403). This also keeps parity with the
+  # Pulumi module, which leaves these unset unless explicitly requested.
   database_options = var.spec.database_options != null ? {
     password_policy           = coalesce(var.spec.database_options.password_policy, "good")
     requires_username         = coalesce(var.spec.database_options.requires_username, false)
     disable_signup            = coalesce(var.spec.database_options.disable_signup, false)
     brute_force_protection    = coalesce(var.spec.database_options.brute_force_protection, true)
-    password_history_size     = coalesce(var.spec.database_options.password_history_size, 5)
-    password_no_personal_info = coalesce(var.spec.database_options.password_no_personal_info, true)
-    password_dictionary       = coalesce(var.spec.database_options.password_dictionary, true)
+    password_history_size     = coalesce(var.spec.database_options.password_history_size, 0)
+    password_no_personal_info = coalesce(var.spec.database_options.password_no_personal_info, false)
+    password_dictionary       = coalesce(var.spec.database_options.password_dictionary, false)
     mfa_enabled               = coalesce(var.spec.database_options.mfa_enabled, false)
   } : null
 

--- a/apis/dev/planton/provider/auth0/auth0connection/v1/iac/tf/variables.tf
+++ b/apis/dev/planton/provider/auth0/auth0connection/v1/iac/tf/variables.tf
@@ -57,13 +57,17 @@ variable "spec" {
       brute_force_protection = optional(bool, true)
 
       # password_history_size is the number of previous passwords to check against (0-24).
-      password_history_size = optional(number, 5)
+      # Requires Auth0's paid "password-advanced-options" entitlement, so it defaults
+      # to 0 (disabled) - a non-zero default 403s on free/lower-tier tenants.
+      password_history_size = optional(number, 0)
 
       # password_no_personal_info prevents passwords containing user's personal information.
-      password_no_personal_info = optional(bool, true)
+      # Requires Auth0's paid "password-advanced-options" entitlement, so it defaults to false.
+      password_no_personal_info = optional(bool, false)
 
       # password_dictionary enables checking passwords against a dictionary of common passwords.
-      password_dictionary = optional(bool, true)
+      # Requires Auth0's paid "password-advanced-options" entitlement, so it defaults to false.
+      password_dictionary = optional(bool, false)
 
       # mfa_enabled enables Multi-Factor Authentication for this connection.
       mfa_enabled = optional(bool, false)

--- a/apis/dev/planton/provider/auth0/auth0connection/v1/spec.proto
+++ b/apis/dev/planton/provider/auth0/auth0connection/v1/spec.proto
@@ -164,7 +164,9 @@ message Auth0DatabaseOptions {
   // password_history_size is the number of previous passwords to check against.
   // Users cannot reuse passwords from their history. Set to 0 to disable.
   // Valid range: 0-24
-  // Default: 5
+  // Requires Auth0's paid "password-advanced-options" entitlement; leaving it
+  // unset avoids a 403 on free/lower-tier tenants.
+  // Default: 0 (disabled)
   int32 password_history_size = 5 [(buf.validate.field).int32 = {
     gte: 0
     lte: 24
@@ -172,12 +174,16 @@ message Auth0DatabaseOptions {
 
   // password_no_personal_info prevents passwords containing user's personal information
   // (name, username, email). Recommended for security.
-  // Default: true
+  // Requires Auth0's paid "password-advanced-options" entitlement; leaving it
+  // unset avoids a 403 on free/lower-tier tenants.
+  // Default: false (disabled)
   bool password_no_personal_info = 6;
 
   // password_dictionary enables checking passwords against a dictionary of common passwords.
   // When true, users cannot use common/weak passwords.
-  // Default: true
+  // Requires Auth0's paid "password-advanced-options" entitlement; leaving it
+  // unset avoids a 403 on free/lower-tier tenants.
+  // Default: false (disabled)
   bool password_dictionary = 7;
 
   // mfa_enabled enables Multi-Factor Authentication for this connection.


### PR DESCRIPTION
## Summary

`Auth0Connection`'s Terraform module enabled three "advanced password options" by default, but they require Auth0's paid `password-advanced-options` entitlement. On a free/lower-tier tenant Auth0 rejects the deploy with `403 Forbidden: Subscription missing entitlement: password-advanced-options`, which broke `e2e-auth0` (`TestAuth0Connection_Terraform/minimal`). The Pulumi module never applied these defaults, so the two engines also diverged.

This PR defaults those options to **disabled**, matching Pulumi, so the component deploys on any Auth0 plan. Users with the entitlement can still opt in explicitly.

| Field | Old default | New default |
|-------|-------------|-------------|
| `password_history_size` | `5` | `0` (disabled) |
| `password_no_personal_info` | `true` | `false` |
| `password_dictionary` | `true` | `false` |

## Root cause

The effective default lived in `iac/tf/variables.tf`'s `optional(...)`, which fills the value *before* `locals.tf`'s `coalesce` runs. So changing `locals.tf` alone would not have fixed the 403 — `variables.tf` had to change too.

## Changes

- **`iac/tf/variables.tf`** (primary fix): `optional(number, 0)` / `optional(bool, false)` / `optional(bool, false)` with entitlement comments.
- **`iac/tf/locals.tf`**: `coalesce` fallbacks set to `0`/`false`/`false` (defensive, consistent).
- **`spec.proto`**: doc comments updated (defaults disabled + paid entitlement).
- **Pulumi**: no change — already off by default; this restores parity.
- **Docs**: `catalog-page.md`, `docs/README.md`, `README.md`, `iac/tf/README.md`, and `iac/hack/manifest.yaml` annotated with the paid-entitlement note.
- **Changelog**: `_changelog/2026-07/2026-07-03-152700-auth0connection-advanced-password-opt-in.md`.

## Impact

- Behavioral (Terraform only): manifests relying on the implicit `5`/`true`/`true` defaults will now deploy with these options disabled; opt in explicitly if you hold the entitlement. This matches the Pulumi behavior already in effect.
- No proto wire change (field numbers/types unchanged).

## Test plan

- [ ] Dispatch `e2e-auth0`; `TestAuth0Connection_Terraform/minimal` should now deploy on the free-tier tenant and pass.